### PR TITLE
Add send-verify-email to KeycloakUserClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
 
 Easy Authentication and Authorization with Keycloak in .NET and ASP.NET Core.
 
-Package                                | Version                                                                                                                                  | Description
----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------
-`Keycloak.AuthServices.Authentication` | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Authentication.svg)](https://nuget.org/packages/Keycloak.AuthServices.Authentication)                         | Keycloak Authentication JWT + OICD
-`Keycloak.AuthServices.Authorization`  | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Authorization.svg)](https://nuget.org/packages/Keycloak.AuthServices.Authorization) | Authorization Services. Use Keycloak as authorization server
-`Keycloak.AuthServices.Sdk`            | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Sdk.svg)](https://nuget.org/packages/Keycloak.AuthServices.Sdk)     | HTTP API integration with Keycloak
-
+| Package                                | Version                                                                                                                                              | Description                                                  |
+|----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| `Keycloak.AuthServices.Authentication` | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Authentication.svg)](https://nuget.org/packages/Keycloak.AuthServices.Authentication) | Keycloak Authentication JWT + OICD                           |
+| `Keycloak.AuthServices.Authorization`  | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Authorization.svg)](https://nuget.org/packages/Keycloak.AuthServices.Authorization)   | Authorization Services. Use Keycloak as authorization server |
+| `Keycloak.AuthServices.Sdk`            | [![Nuget](https://img.shields.io/nuget/v/Keycloak.AuthServices.Sdk.svg)](https://nuget.org/packages/Keycloak.AuthServices.Sdk)                       | HTTP API integration with Keycloak                           |
 [![GitHub Actions Build History](https://buildstats.info/github/chart/nikiforovall/keycloak-authorization-services-dotnet?branch=main&includeBuildsFromPullRequest=false)](https://github.com/NikiforovAll/keycloak-authorization-services-dotnet/actions)
 
 ## Example
@@ -126,6 +125,7 @@ Keycloak API clients.
 | IKeycloakClient                  | Unified HTTP client - IKeycloakRealmClient, IKeycloakProtectedResourceClient |
 | IKeycloakRealmClient             | Keycloak realm API                                                           |
 | IKeycloakProtectedResourceClient | Protected resource API                                                       |
+| IKeycloakUserClient              | Keycloak user API                                                            |
 | IKeycloakProtectionClient        | Authorization server API, used by `AddKeycloakAuthorization`                 |
 
 ```csharp

--- a/src/Keycloak.AuthServices.Sdk/Admin/Constants/KeycloakClientApiConstants.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Constants/KeycloakClientApiConstants.cs
@@ -32,5 +32,7 @@ internal static class KeycloakClientApiConstants
 
     internal const string CreateUser = $"{GetRealm}/users";
 
+    internal const string SendVerifyEmail = $"{GetRealm}/users/{{userId}}/send-verify-email";
+
     #endregion
 }

--- a/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakUserClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakUserClient.cs
@@ -10,12 +10,32 @@ using Refit;
 public interface IKeycloakUserClient
 {
     /// <summary>
-    /// Create a new user
+    /// Create a new user.
     /// </summary>
-    /// <param name="realm"></param>
-    /// <param name="user"></param>
+    /// <remarks>
+    /// Username must be unique.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="user">User representation.</param>
     /// <returns></returns>
     [Post(KeycloakClientApiConstants.CreateUser)]
     [Headers("Accept: application/json", "Content-Type: application/json")]
     Task CreateUser(string realm, [Body] User user);
+
+    /// <summary>
+    /// Send an email-verification email to the user.
+    /// </summary>
+    /// <remarks>
+    /// An email contains a link the user can click to verify their email address.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="userId">User ID.</param>
+    /// <param name="clientId">Client ID.</param>
+    /// <param name="redirectUri">Redirect URI. The default for the redirect is the account client.</param>
+    /// <returns></returns>
+    [Put(KeycloakClientApiConstants.SendVerifyEmail)]
+    [Headers("Accept: application/json", "Content-Type: application/json")]
+    Task SendVerifyEmail(string realm, string userId,
+        [Query][AliasAs("client_id")] string? clientId = default,
+        [Query][AliasAs("redirect_uri")] string? redirectUri = default);
 }

--- a/src/Keycloak.AuthServices.Sdk/Admin/Models/User.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Models/User.cs
@@ -17,7 +17,7 @@ public class User
     public string? Email { get; init; }
     public bool? EmailVerified { get; init; }
     public bool? Enabled { get; init; }
-    public FederatedIdentity? FederatedIdentities { get; init; }
+    public FederatedIdentity[]? FederatedIdentities { get; init; }
     public string? FederationLink { get; init; }
     public string? FirstName { get; init; }
     public string[]? Groups { get; init; }
@@ -25,8 +25,8 @@ public class User
     public string? LastName { get; init; }
     public int? NotBefore { get; init; }
     public string? Origin { get; init; }
-    public Dictionary<string, string>? RealmRoles { get; init; }
-    public Dictionary<string, string>? RequiredActions { get; init; }
+    public string[]? RealmRoles { get; init; }
+    public string[]? RequiredActions { get; init; }
     public string? Self { get; init; }
     public string? ServiceAccountClientId { get; init; }
     public string? Username { get; init; }
@@ -55,7 +55,7 @@ public class UserConsent
 {
     public string? ClientId { get; init; }
     public long? CreatedDate { get; init; }
-    public string? LastUpdatedDate { get; init; }
+    public long? LastUpdatedDate { get; init; }
     public string[]? GrantedClientScopes { get; init; }
 }
 


### PR DESCRIPTION
Adds the send-verify-email action in the User management API.

About the wrong mappings, I didn't pay much attention to some fields in the User model before, should be fixed now.