### PR TITLE
Roles / Claims Transformations: only add the roles once

### DIFF
--- a/KeycloakAuthorizationServicesDotNet.sln
+++ b/KeycloakAuthorizationServicesDotNet.sln
@@ -49,14 +49,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazor.Client", "samples\Bl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blazor.Shared", "samples\Blazor\Shared\Blazor.Shared.csproj", "{FA611377-9C42-461F-8767-911CA6C6DC83}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AuthZGettingStarted", "samples\AuthZGettingStarted\AuthZGettingStarted.csproj", "{A7C96E1A-8CD6-4BFA-8128-9875B607BEF5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AuthZGettingStarted", "samples\AuthZGettingStarted\AuthZGettingStarted.csproj", "{A7C96E1A-8CD6-4BFA-8128-9875B607BEF5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{96857509-627A-4FD2-AC82-34387619A7B1}"
 	ProjectSection(SolutionItems) = preProject
 		tests\Directory.Build.props = tests\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Keycloak.AuthServices.Sdk.Tests", "tests\Keycloak.AuthServices.Sdk.Tests\Keycloak.AuthServices.Sdk.Tests.csproj", "{A85B6B1E-2030-47BE-9B9F-F645B08E501D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Keycloak.AuthServices.Sdk.Tests", "tests\Keycloak.AuthServices.Sdk.Tests\Keycloak.AuthServices.Sdk.Tests.csproj", "{A85B6B1E-2030-47BE-9B9F-F645B08E501D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Keycloak.AuthServices.Authentication.Tests", "tests\Keycloak.AuthServices.Authentication.Tests\Keycloak.AuthServices.Authentication.Tests.csproj", "{FE34728A-25AA-44E1-A3A6-AB500307C406}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -112,6 +114,10 @@ Global
 		{A85B6B1E-2030-47BE-9B9F-F645B08E501D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A85B6B1E-2030-47BE-9B9F-F645B08E501D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A85B6B1E-2030-47BE-9B9F-F645B08E501D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE34728A-25AA-44E1-A3A6-AB500307C406}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE34728A-25AA-44E1-A3A6-AB500307C406}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE34728A-25AA-44E1-A3A6-AB500307C406}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE34728A-25AA-44E1-A3A6-AB500307C406}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -130,6 +136,7 @@ Global
 		{FA611377-9C42-461F-8767-911CA6C6DC83} = {C0EADAAF-E21C-4C90-9E78-45545006AADB}
 		{A7C96E1A-8CD6-4BFA-8128-9875B607BEF5} = {AEBE10B1-96B1-4060-B8C1-1F9BFA7A586C}
 		{A85B6B1E-2030-47BE-9B9F-F645B08E501D} = {96857509-627A-4FD2-AC82-34387619A7B1}
+		{FE34728A-25AA-44E1-A3A6-AB500307C406} = {96857509-627A-4FD2-AC82-34387619A7B1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E1907BFD-C144-4B48-AA40-972F499D4E08}

--- a/src/Keycloak.AuthServices.Authentication/Claims/KeycloakRolesClaimsTransformation.cs
+++ b/src/Keycloak.AuthServices.Authentication/Claims/KeycloakRolesClaimsTransformation.cs
@@ -33,6 +33,7 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
     /// Initializes a new instance of the <see cref="KeycloakRolesClaimsTransformation"/> class.
     /// </summary>
     /// <param name="roleClaimType">Type of the role claim.</param>
+    /// <param name="roleSource"><see cref="RolesClaimTransformationSource"/></param>
     /// <param name="audience">The audience.</param>
     public KeycloakRolesClaimsTransformation(
         string roleClaimType,
@@ -84,7 +85,12 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
             foreach (var role in clientRoles.EnumerateArray())
             {
                 var value = role.GetString();
-                if (!string.IsNullOrWhiteSpace(value))
+
+                var matchingClaim = identity.Claims.FirstOrDefault(claim => 
+                    claim.Type.Equals(this.roleClaimType, StringComparison.InvariantCultureIgnoreCase) && 
+                    claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase)); 
+
+                if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
                 {
                     identity.AddClaim(new Claim(this.roleClaimType, value));
                 }
@@ -92,7 +98,8 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
 
             return Task.FromResult(result);
         }
-        else if (this.roleSource == RolesClaimTransformationSource.Realm)
+
+        if (this.roleSource == RolesClaimTransformationSource.Realm)
         {
             var realmAccessValue = principal.FindFirst("realm_access")?.Value;
             if (string.IsNullOrWhiteSpace(realmAccessValue))
@@ -111,7 +118,12 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
                 foreach (var role in rolesElement.EnumerateArray())
                 {
                     var value = role.GetString();
-                    if (!string.IsNullOrWhiteSpace(value))
+
+                    var matchingClaim = identity.Claims.FirstOrDefault(claim => 
+                        claim.Type.Equals(this.roleClaimType, StringComparison.InvariantCultureIgnoreCase) && 
+                        claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase));
+
+                    if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
                     {
                         identity.AddClaim(new Claim(this.roleClaimType, value));
                     }

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
@@ -1,0 +1,60 @@
+namespace Keycloak.AuthServices.Authentication.Tests.Claims;
+
+using System.Security.Claims;
+using Authentication.Claims;
+using Common;
+using FluentAssertions;
+
+public class KeycloakRolesClaimsTransformationTests
+{
+    [Theory]
+    [InlineData(RolesClaimTransformationSource.Realm)]
+    [InlineData(RolesClaimTransformationSource.ResourceAccess)]
+    public async Task ClaimsTransformationShouldMap(RolesClaimTransformationSource roleSource)
+    {
+        // create the service
+        var target = new KeycloakRolesClaimsTransformation(ClaimTypes.Role, roleSource, MyAudience);
+
+        // The fixture
+        var claimsPrincipal = GetClaimsPrincipal();
+
+        // This should work many times
+        foreach (var _ in Enumerable.Range(1, 3))
+        {
+            claimsPrincipal = await target.TransformAsync(claimsPrincipal);
+            claimsPrincipal.HasClaim(ClaimTypes.Role, MyFirstClaim).Should().BeTrue();
+            claimsPrincipal.HasClaim(ClaimTypes.Role, MySecondClaim).Should().BeTrue();
+            claimsPrincipal.Claims.Count(item => ClaimTypes.Role == item.Type).Should().Be(2);
+        }
+    }
+
+    // The resource_access claim type
+    private const string MyResourceClaimType = "resource_access";
+    private const string MyResourceClaimValue = $"{{\u0022{MyAudience}\u0022:{{\u0022roles\u0022:[\u0022{MyFirstClaim}\u0022,\u0022{MySecondClaim}\u0022]}}}}";
+
+    // The realm_access claim type
+    private const string MyRealmClaimType = "realm_access";
+    private const string MyRealmClaimValue = $"{{\u0022roles\u0022:[\u0022{MyFirstClaim}\u0022,\u0022{MySecondClaim}\u0022]}}";
+
+    // Fake claim values
+    private const string MyFirstClaim = "my_client_app_role_user";
+    private const string MySecondClaim = "my_client_app_role_super_user";
+
+    // The issuer/original issuer
+    private const string MyUrl = "https://keycloak.mydomain.com/realms/my_realm";
+
+    // The value type should be JSON
+    private const string MyValueType = "JSON";
+
+    // The audience for the resource_access
+    private const string MyAudience = "my-audience";
+
+    // Get a claims principal that has all the appropriate claim details required for testing
+    private static ClaimsPrincipal GetClaimsPrincipal() =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(MyResourceClaimType, MyResourceClaimValue, MyValueType, MyUrl, MyUrl),
+            new Claim(MyRealmClaimType, MyRealmClaimValue, MyValueType, MyUrl, MyUrl),
+        }));
+
+}

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
@@ -19,7 +19,7 @@ public class KeycloakRolesClaimsTransformationTests
         var claimsPrincipal = GetClaimsPrincipal();
 
         // This should work many times
-        foreach (var _ in Enumerable.Range(1, 3))
+        for(var testCount = 0; testCount < 3; testCount++)
         {
             claimsPrincipal = await target.TransformAsync(claimsPrincipal);
             claimsPrincipal.HasClaim(ClaimTypes.Role, MyFirstClaim).Should().BeTrue();
@@ -30,11 +30,11 @@ public class KeycloakRolesClaimsTransformationTests
 
     // The resource_access claim type
     private const string MyResourceClaimType = "resource_access";
-    private const string MyResourceClaimValue = $"{{\u0022{MyAudience}\u0022:{{\u0022roles\u0022:[\u0022{MyFirstClaim}\u0022,\u0022{MySecondClaim}\u0022]}}}}";
+    private const string MyResourceClaimValue = @$"{{""{MyAudience}"":{{""roles"":[""{MyFirstClaim}"",""{MySecondClaim}""]}}}}";
 
     // The realm_access claim type
     private const string MyRealmClaimType = "realm_access";
-    private const string MyRealmClaimValue = $"{{\u0022roles\u0022:[\u0022{MyFirstClaim}\u0022,\u0022{MySecondClaim}\u0022]}}";
+    private const string MyRealmClaimValue = @$"{{""roles"":[""{MyFirstClaim}"",""{MySecondClaim}""]}}";
 
     // Fake claim values
     private const string MyFirstClaim = "my_client_app_role_user";

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Keycloak.AuthServices.Authentication.Tests.csproj
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Keycloak.AuthServices.Authentication.Tests.csproj
@@ -9,13 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Keycloak.AuthServices.Authentication\Keycloak.AuthServices.Authentication.csproj" />
     <ProjectReference Include="..\..\src\Keycloak.AuthServices.Common\Keycloak.AuthServices.Common.csproj" />
   </ItemGroup>

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Keycloak.AuthServices.Authentication.Tests.csproj
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Keycloak.AuthServices.Authentication.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Keycloak.AuthServices.Authentication\Keycloak.AuthServices.Authentication.csproj" />
+    <ProjectReference Include="..\..\src\Keycloak.AuthServices.Common\Keycloak.AuthServices.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Usings.cs
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Usings.cs
@@ -1,1 +1,0 @@
-global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/Keycloak.AuthServices.Authentication.Tests/Usings.cs
+++ b/tests/Keycloak.AuthServices.Authentication.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
This avoids having an infinite number of roles get added to the ClaimsPrincipal when mapping the resource/realm access to roles.

This is in reference to https://github.com/NikiforovAll/keycloak-authorization-services-dotnet/issues/33