### PR TITLE
remove unused netcore 2.2 era nuget

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <ItemGroup Label="Core">
     <PackageVersion Include="IdentityModel.AspNetCore" Version="4.1.2"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1"/>
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="6.0.1"/>
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0"/>

--- a/src/Keycloak.AuthServices.Authorization/Keycloak.AuthServices.Authorization.csproj
+++ b/src/Keycloak.AuthServices.Authorization/Keycloak.AuthServices.Authorization.csproj
@@ -14,9 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed Microsoft.AspNetCore.Authentication.Abstractions 2.2.0 dependency.
It's not needed for build & runtime.