### PR TITLE
feat: Convert RolesClaimTransformationSource to flags 

### DIFF
--- a/docs/configuration/configuration-authorization.md
+++ b/docs/configuration/configuration-authorization.md
@@ -61,22 +61,28 @@ Here an example of how to configure client role:
 There are three options to determine a source for the roles:
 
 ```csharp
+[Flags]
 public enum RolesClaimTransformationSource
 {
     /// <summary>
-    /// No Transformation. Default
+    /// Specifies that no transformation should be applied from the source.
     /// </summary>
-    None,
+    None = 0,
 
     /// <summary>
-    /// Use realm roles as source
+    /// Specifies that transformation should be applied to the realm.
     /// </summary>
-    Realm,
+    Realm = 1 << 0,
 
     /// <summary>
-    /// Use client roles as source
+    /// Specifies that transformation should be applied to the resource access.
     /// </summary>
-    ResourceAccess
+    ResourceAccess = 1 << 1,
+
+    /// <summary>
+    /// Specifies that transformation should be applied to all sources.
+    /// </summary>
+    All = Realm | ResourceAccess
 }
 ```
 
@@ -134,5 +140,14 @@ Result = ["default-roles-test","offline_access","uma_authorization"]
 If we specify `KeycloakAuthorizationOptions.EnableRolesMapping = RolesClaimTransformationSource.ResourceAccess` and `KeycloakAuthorizationOptions.RolesResource="test-client"` the roles are taken from $token.realm_access.test-client.roles.
 
 Result = ["manage-account","manage-account-links","view-profile"]
+
+See below the table for possible combinations:
+
+| EnableRolesMapping | RolesResource | Result                                                                                                               |
+|--------------------|---------------|----------------------------------------------------------------------------------------------------------------------|
+| Realm              | N/A           | `["default-roles-test","offline_access","uma_authorization"]`                                                        |
+| ResourceAccess     | `test-client` | `["manage-account","manage-account-links","view-profile"]`                                                           |
+| All                | `test-client` | `["default-roles-test","offline_access","uma_authorization","manage-account","manage-account-links","view-profile"]` |
+
 
 The target claim can be configured `KeycloakAuthorizationOptions.RoleClaimType`, the default value is "role".

--- a/src/Keycloak.AuthServices.Authorization/Claims/KeycloakRolesClaimsTransformation.cs
+++ b/src/Keycloak.AuthServices.Authorization/Claims/KeycloakRolesClaimsTransformation.cs
@@ -70,7 +70,7 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
 
         var result = principal.Clone();
 
-        if (this.roleSource == RolesClaimTransformationSource.ResourceAccess)
+        if (this.roleSource.HasFlag(RolesClaimTransformationSource.ResourceAccess))
         {
             var resourceAccessValue = principal.FindFirst("resource_access")?.Value;
             if (string.IsNullOrWhiteSpace(resourceAccessValue))
@@ -107,11 +107,9 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
                     identity.AddClaim(new Claim(this.roleClaimType, value));
                 }
             }
-
-            return Task.FromResult(result);
         }
 
-        if (this.roleSource == RolesClaimTransformationSource.Realm)
+        if (this.roleSource.HasFlag(RolesClaimTransformationSource.Realm))
         {
             var realmAccessValue = principal.FindFirst("realm_access")?.Value;
             if (string.IsNullOrWhiteSpace(realmAccessValue))
@@ -144,8 +142,6 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
                         identity.AddClaim(new Claim(this.roleClaimType, value));
                     }
                 }
-
-                return Task.FromResult(result);
             }
         }
 

--- a/src/Keycloak.AuthServices.Authorization/KeycloakAuthorizationOptions.cs
+++ b/src/Keycloak.AuthServices.Authorization/KeycloakAuthorizationOptions.cs
@@ -32,20 +32,26 @@ public class KeycloakAuthorizationOptions : KeycloakInstallationOptions
 /// <summary>
 /// RolesClaimTransformationSource
 /// </summary>
+[Flags]
 public enum RolesClaimTransformationSource
 {
     /// <summary>
     /// Specifies that no transformation should be applied from the source.
     /// </summary>
-    None,
+    None = 0,
 
     /// <summary>
     /// Specifies that transformation should be applied to the realm.
     /// </summary>
-    Realm,
+    Realm = 1 << 0,
 
     /// <summary>
     /// Specifies that transformation should be applied to the resource access.
     /// </summary>
-    ResourceAccess
+    ResourceAccess = 1 << 1,
+
+    /// <summary>
+    /// Specifies that transformation should be applied to all sources.
+    /// </summary>
+    All = Realm | ResourceAccess
 }

--- a/tests/Keycloak.AuthServices.Authorization.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
+++ b/tests/Keycloak.AuthServices.Authorization.Tests/Claims/KeycloakRolesClaimsTransformationTests.cs
@@ -10,6 +10,7 @@ public class KeycloakRolesClaimsTransformationTests
     [Theory]
     [InlineData(RolesClaimTransformationSource.Realm)]
     [InlineData(RolesClaimTransformationSource.ResourceAccess)]
+    [InlineData(RolesClaimTransformationSource.All)]
     public async Task ClaimsTransformationShouldMap(RolesClaimTransformationSource roleSource)
     {
         var target = new KeycloakRolesClaimsTransformation(ClaimTypes.Role, roleSource, ClientId);
@@ -23,6 +24,20 @@ public class KeycloakRolesClaimsTransformationTests
             claimsPrincipal.HasClaim(ClaimTypes.Role, AppRoleSuperUserClaim).Should().BeTrue();
             claimsPrincipal.Claims.Count(item => ClaimTypes.Role == item.Type).Should().Be(2);
         }
+    }
+
+    [Fact]
+    public async Task ClaimsTransformationShouldHandleNoneSource()
+    {
+        var target = new KeycloakRolesClaimsTransformation(
+            ClaimTypes.Role,
+            RolesClaimTransformationSource.None,
+            ClientId
+        );
+        var claimsPrincipal = GetClaimsPrincipal(MyRealmClaimValue, MyResourceClaimValue);
+
+        claimsPrincipal = await target.TransformAsync(claimsPrincipal);
+        claimsPrincipal.Claims.Count(item => ClaimTypes.Role == item.Type).Should().Be(0);
     }
 
     [Fact]


### PR DESCRIPTION
- Convert RolesClaimTransformationSource to flags to allow for combining sources. 
- Add "All" flag for convenience.