### PR TITLE
fix: Remove early returns in claims transformation

### DIFF
--- a/src/Keycloak.AuthServices.Authorization/Claims/KeycloakRolesClaimsTransformation.cs
+++ b/src/Keycloak.AuthServices.Authorization/Claims/KeycloakRolesClaimsTransformation.cs
@@ -73,38 +73,34 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
         if (this.roleSource.HasFlag(RolesClaimTransformationSource.ResourceAccess))
         {
             var resourceAccessValue = principal.FindFirst("resource_access")?.Value;
-            if (string.IsNullOrWhiteSpace(resourceAccessValue))
+            if (!string.IsNullOrWhiteSpace(resourceAccessValue))
             {
-                return Task.FromResult(result);
-            }
-
-            using var resourceAccess = JsonDocument.Parse(resourceAccessValue);
-            var containsAudienceRoles = resourceAccess.RootElement.TryGetProperty(
-                this.audience,
-                out var rolesElement
-            );
-
-            if (!containsAudienceRoles)
-            {
-                return Task.FromResult(result);
-            }
-
-            var clientRoles = rolesElement.GetProperty("roles");
-
-            foreach (var role in clientRoles.EnumerateArray())
-            {
-                var value = role.GetString();
-
-                var matchingClaim = identity.Claims.FirstOrDefault(claim =>
-                    claim.Type.Equals(
-                        this.roleClaimType,
-                        StringComparison.InvariantCultureIgnoreCase
-                    ) && claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase)
+                using var resourceAccess = JsonDocument.Parse(resourceAccessValue);
+                var containsAudienceRoles = resourceAccess.RootElement.TryGetProperty(
+                    this.audience,
+                    out var rolesElement
                 );
 
-                if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
+                if (containsAudienceRoles)
                 {
-                    identity.AddClaim(new Claim(this.roleClaimType, value));
+                    var clientRoles = rolesElement.GetProperty("roles");
+
+                    foreach (var role in clientRoles.EnumerateArray())
+                    {
+                        var value = role.GetString();
+
+                        var matchingClaim = identity.Claims.FirstOrDefault(claim =>
+                            claim.Type.Equals(
+                                this.roleClaimType,
+                                StringComparison.InvariantCultureIgnoreCase
+                            ) && claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase)
+                        );
+
+                        if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
+                        {
+                            identity.AddClaim(new Claim(this.roleClaimType, value));
+                        }
+                    }
                 }
             }
         }
@@ -112,34 +108,32 @@ public class KeycloakRolesClaimsTransformation : IClaimsTransformation
         if (this.roleSource.HasFlag(RolesClaimTransformationSource.Realm))
         {
             var realmAccessValue = principal.FindFirst("realm_access")?.Value;
-            if (string.IsNullOrWhiteSpace(realmAccessValue))
+            if (!string.IsNullOrWhiteSpace(realmAccessValue))
             {
-                return Task.FromResult(result);
-            }
+                using var realmAccess = JsonDocument.Parse(realmAccessValue);
 
-            using var realmAccess = JsonDocument.Parse(realmAccessValue);
+                var containsRoles = realmAccess.RootElement.TryGetProperty(
+                    "roles",
+                    out var rolesElement
+                );
 
-            var containsRoles = realmAccess.RootElement.TryGetProperty(
-                "roles",
-                out var rolesElement
-            );
-
-            if (containsRoles)
-            {
-                foreach (var role in rolesElement.EnumerateArray())
+                if (containsRoles)
                 {
-                    var value = role.GetString();
-
-                    var matchingClaim = identity.Claims.FirstOrDefault(claim =>
-                        claim.Type.Equals(
-                            this.roleClaimType,
-                            StringComparison.InvariantCultureIgnoreCase
-                        ) && claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase)
-                    );
-
-                    if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
+                    foreach (var role in rolesElement.EnumerateArray())
                     {
-                        identity.AddClaim(new Claim(this.roleClaimType, value));
+                        var value = role.GetString();
+
+                        var matchingClaim = identity.Claims.FirstOrDefault(claim =>
+                            claim.Type.Equals(
+                                this.roleClaimType,
+                                StringComparison.InvariantCultureIgnoreCase
+                            ) && claim.Value.Equals(value, StringComparison.InvariantCultureIgnoreCase)
+                        );
+
+                        if (matchingClaim is null && !string.IsNullOrWhiteSpace(value))
+                        {
+                            identity.AddClaim(new Claim(this.roleClaimType, value));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Issue:**
Current implementation will flow to an early return statement when all of the following requirements are met:
- `RolesClaimTransformationSource.All` is **set**
- The user does **not** have any roles in the requested `resource`
- The user does have a realm role

**Expected Result:**
The realm role will be applied to the principal.

**Actual Result:**
The realm role is **not** applied to the principal.

**Resolution:**
- Remove early returns and allow the method to flow to the end where it will return with the final principal.
- Added tests to check for this case.