### PR TITLE
fix: Added overload of AddKeycloakWebAppAuthentication

### DIFF
--- a/src/Keycloak.AuthServices.Authentication/WebAppExtensions/KeycloakWebAppServiceCollectionExtensions.cs
+++ b/src/Keycloak.AuthServices.Authentication/WebAppExtensions/KeycloakWebAppServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Keycloak.AuthServices.Authentication;
+namespace Keycloak.AuthServices.Authentication;
 
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -41,6 +41,45 @@ public static partial class KeycloakWebAppServiceCollectionExtensions
         return builder.AddKeycloakWebApp(
             configuration,
             configSectionName,
+            openIdConnectScheme,
+            cookieScheme,
+            displayName
+        );
+    }
+
+    /// <summary>
+    /// Add authentication with Keycloak
+    /// This method expects the configuration file will have a section, (by default named "Keycloak"), with the necessary settings to
+    /// initialize the authentication options.
+    /// </summary>
+    /// <param name="services">Service collection to which to add authentication.</param>
+    /// <param name="configuration">The IConfiguration object.</param>
+    /// <param name="configSectionName">The name of the configuration section with the necessary
+    /// settings to initialize authentication options.</param>
+    /// <param name="openIdConnectScheme">Optional name for the open id connect authentication scheme
+    /// (by default OpenIdConnectDefaults.AuthenticationScheme). This can be specified when you want to support
+    /// several OpenIdConnect identity providers.</param>
+    /// <param name="cookieScheme">Optional name for the cookie authentication scheme
+    /// (by default CookieAuthenticationDefaults.AuthenticationScheme).</param>
+    /// /// <param name="configureOpenIdConnectOptions"></param>
+    /// <param name="displayName">A display name for the authentication handler.</param>
+    /// <returns>The authentication builder to chain extension methods.</returns>
+    public static KeycloakWebAppAuthenticationBuilder AddKeycloakWebAppAuthentication(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string configSectionName = KeycloakAuthenticationOptions.Section,
+        string openIdConnectScheme = OpenIdConnectDefaults.AuthenticationScheme,
+        string cookieScheme = CookieAuthenticationDefaults.AuthenticationScheme,
+        Action<OpenIdConnectOptions>? configureOpenIdConnectOptions=null,
+        string? displayName = null
+    )
+    {
+        var builder = services.AddAuthentication(openIdConnectScheme);
+
+        return builder.AddKeycloakWebApp(
+            configuration.GetRequiredSection(configSectionName),
+            null,
+            configureOpenIdConnectOptions,
             openIdConnectScheme,
             cookieScheme,
             displayName

--- a/tests/TestWebApi/Properties/launchSettings.json
+++ b/tests/TestWebApi/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TestWebApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:19494;http://localhost:19495"
+    }
+  }
+}

--- a/tests/TestWebApiWithControllers/Properties/launchSettings.json
+++ b/tests/TestWebApiWithControllers/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "TestWebApiWithControllers": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:19496;http://localhost:19497"
+    }
+  }
+}


### PR DESCRIPTION
Added overload of AddKeycloakWebAppAuthentication due to dotnet 8.0 causing breaking changes.  The sub claim is not mapped into the user's claims list without disabling claimMapping. Exposing the ConfigureOpenIdConnectionOptions allows this to be worked around.