### PR TITLE
feat: upgrade microsoft.kiota dependencies

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,13 +16,13 @@
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Label="Kiota">
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.9.12" />
-    <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.1.7" />
-    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.4.3" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.2.4" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.3.3" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.1.5" />
-    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.2.2" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Http.HttpClientLibrary" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Form" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Json" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Multipart" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Kiota.Serialization.Text" Version="1.13.1" />
   </ItemGroup>
   <ItemGroup Label="Release">
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />


### PR DESCRIPTION
The `Microsoft.Kiota` dependencies are upgraded with this pull request.  
This makes it possible to use `KeyCloak.AuthServices.SdK.Kiota` and `Microsoft.Graph` in the same project. 

Fixes #147 