### PR TITLE
#150 Add .NET 8 support to samples projects

### DIFF
--- a/samples/AuthGettingStarted/AuthGettingStarted.csproj
+++ b/samples/AuthGettingStarted/AuthGettingStarted.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Api</RootNamespace>
     <IsPackable>false</IsPackable>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AuthorizationAndCleanArchitecture/AuthorizationAndCleanArchitecture.csproj
+++ b/samples/AuthorizationAndCleanArchitecture/AuthorizationAndCleanArchitecture.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Api</RootNamespace>
     <IsPackable>false</IsPackable>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/AuthorizationGettingStarted/AuthorizationGettingStarted.csproj
+++ b/samples/AuthorizationGettingStarted/AuthorizationGettingStarted.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" />
     <PackageReference Include="Serilog.Extensions.Hosting" />

--- a/samples/Blazor/Client/Blazor.Client.csproj
+++ b/samples/Blazor/Client/Blazor.Client.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />

--- a/samples/Blazor/Server/Blazor.Server.csproj
+++ b/samples/Blazor/Server/Blazor.Server.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" />
     <PackageReference Include="Serilog.AspNetCore" />

--- a/samples/Blazor/Shared/Blazor.Shared.csproj
+++ b/samples/Blazor/Shared/Blazor.Shared.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>BlazorSample</RootNamespace>
     <NoWarn>CS7022</NoWarn>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,32 +1,32 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Duende.AccessTokenManagement" Version="2.1.2" />
+    <PackageVersion Include="Duende.AccessTokenManagement" Version="3.0.0" />
     <PackageVersion Include="Keycloak.AuthServices.Authentication" Version="1.7.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.29" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageVersion Include="MediatR" Version="12.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.29" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="6.0.29" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="6.0.29" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.29" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.29" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
-    <PackageVersion Include="NSwag.AspNetCore" Version="14.0.7" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageVersion Include="MediatR" Version="12.4.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.10" />
+    <PackageVersion Include="NSwag.AspNetCore" Version="14.1.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.SpectreConsole" Version="0.3.3" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
   <ItemGroup Label="Aspire">
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="8.0.1" />
-    <PackageVersion Include="Aspire.Hosting" Version="8.0.1"/>
+    <PackageVersion Include="Aspire.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.4.24156.9" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />


### PR DESCRIPTION
* Setting Blazor.Shared project target framework to .net8

* Setting Blazor.Client project target framework to .net8

* Setting Blazor.Server project target framework to .net8

* Setting AuthGettingStarted project target framework to .net8

* Setting AuthorizationAndCleanArchitecture project target framework to .net8

* Setting AuthorizationGettingStarted project target framework to .net8

* Updating samples nuget packages to latest version