### PR TITLE
feat(plugin): add keycloak-auth-services skill

### DIFF
--- a/README-plugin.md
+++ b/README-plugin.md
@@ -7,6 +7,7 @@ AI coding agent skills for Keycloak administration and Keycloak.AuthServices .NE
 | Skill | Description |
 |-------|-------------|
 | `/keycloak-authservices:keycloak-administration` | Keycloak IAM administration — realms, clients, SSO, RBAC, troubleshooting |
+| `/keycloak-authservices:keycloak-auth-services` | Keycloak.AuthServices .NET library — authentication, authorization, Admin SDK, Protection API |
 
 ## Installation
 
@@ -39,10 +40,11 @@ claude --plugin-dir ./path/to/keycloak-authorization-services-dotnet
 
 ### Verify Installation
 
-After installation, run `/reload-plugins` and the skill becomes available:
+After installation, run `/reload-plugins` and skills become available:
 
 ```
 /keycloak-authservices:keycloak-administration
+/keycloak-authservices:keycloak-auth-services
 ```
 
 ## Plugin Structure
@@ -53,7 +55,7 @@ After installation, run `/reload-plugins` and the skill becomes available:
   marketplace.json                     # Marketplace catalog
 skills/
   keycloak-administration/
-    SKILL.md                           # Main skill instructions
+    SKILL.md                           # Keycloak IAM administration guide
     references/
       realm-management.md              # Realms, users, groups, sessions
       client-configuration.md          # OIDC/SAML clients, scopes, mappers
@@ -64,6 +66,17 @@ skills/
       ha-scalability.md                # Clustering, monitoring, backup/DR
       troubleshooting.md               # Diagnostics and common issues
       integration-examples.md          # .NET, Spring Boot, Node.js examples
+  keycloak-auth-services/
+    SKILL.md                           # .NET library implementation guide
+    references/
+      authentication.md                # JWT Bearer, OIDC, adapter file
+      authorization.md                 # RBAC, realm/client roles, claims
+      resource-protection.md           # Authorization Server, Protected Resource Builder
+      admin-sdk.md                     # Admin REST API (hand-written + Kiota)
+      protection-api.md                # UMA Protection API
+      devex.md                         # Aspire, templates, OpenTelemetry
+      configuration.md                 # All configuration options
+      troubleshooting.md               # Recipes, debugging, migration
 ```
 
 ## License

--- a/skills/keycloak-auth-services/SKILL.md
+++ b/skills/keycloak-auth-services/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: keycloak-auth-services
+description: >-
+  Implementation guide for Keycloak.AuthServices .NET library — authentication (JWT Bearer, OIDC),
+  authorization (RBAC, resource protection, Authorization Server), Admin REST API SDK,
+  Protection API SDK, and developer experience tooling (.NET Aspire, templates, OpenTelemetry).
+  Use when implementing Keycloak integration in .NET apps, configuring authentication/authorization,
+  using the Admin or Protection API, or troubleshooting Keycloak.AuthServices issues.
+  Trigger phrases include "Keycloak.AuthServices", "AddKeycloakWebApiAuthentication",
+  "ProtectedResource", "Admin SDK", "Protection API", "Keycloak .NET".
+user-invocable: true
+---
+
+# Keycloak.AuthServices Implementation Guide
+
+## Quick Start
+
+Choose your task and load the appropriate reference:
+
+1. **JWT Bearer Authentication (Web API)** → Continue below
+2. **OIDC Authentication (Web App)** → Load [authentication.md](references/authentication.md)
+3. **Authorization & RBAC** → Load [authorization.md](references/authorization.md)
+4. **Resource Protection & Authorization Server** → Load [resource-protection.md](references/resource-protection.md)
+5. **Admin REST API SDK** → Load [admin-sdk.md](references/admin-sdk.md)
+6. **Protection API SDK** → Load [protection-api.md](references/protection-api.md)
+7. **Developer Experience (Aspire, Templates)** → Load [devex.md](references/devex.md)
+8. **Configuration Reference** → Load [configuration.md](references/configuration.md)
+9. **Recipes & Troubleshooting** → Load [troubleshooting.md](references/troubleshooting.md)
+
+## Packages Overview
+
+| Package | Purpose |
+|---------|---------|
+| `Keycloak.AuthServices.Authentication` | JWT Bearer (Web API) and OpenID Connect (Web App) authentication |
+| `Keycloak.AuthServices.Authorization` | RBAC (realm/client roles), Authorization Server client, `[ProtectedResource]` attribute |
+| `Keycloak.AuthServices.Sdk` | Hand-written Admin REST API + Protection API HTTP clients |
+| `Keycloak.AuthServices.Sdk.Kiota` | Auto-generated (Kiota) Admin REST API client — full API coverage |
+| `Keycloak.AuthServices.Common` | Shared configuration (`KeycloakInstallationOptions`), claims utilities |
+| `Keycloak.AuthServices.OpenTelemetry` | Metrics and tracing instrumentation |
+| `Keycloak.AuthServices.Aspire.Hosting` | .NET Aspire `KeycloakResource` integration |
+| `Keycloak.AuthServices.Templates` | `dotnet new` project templates |
+
+## Minimal Web API Setup
+
+```bash
+dotnet add package Keycloak.AuthServices.Authentication
+dotnet add package Keycloak.AuthServices.Common
+```
+
+```csharp
+using Keycloak.AuthServices.Authentication;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddKeycloakWebApiAuthentication(builder.Configuration);
+builder.Services.AddAuthorization();
+
+var app = builder.Build();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "Hello World!").RequireAuthorization();
+app.Run();
+```
+
+```json
+// appsettings.json — "Keycloak" section (kebab-case from adapter config)
+{
+  "Keycloak": {
+    "realm": "Test",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "test-client",
+    "verify-token-audience": true,
+    "credentials": {
+      "secret": "your-client-secret"
+    }
+  }
+}
+```
+
+## Configuration Section
+
+All packages bind to `"Keycloak"` config section by default. Key properties:
+
+| Property | Description |
+|----------|-------------|
+| `realm` | Keycloak realm name |
+| `auth-server-url` | Keycloak server URL (e.g., `http://localhost:8080/`) |
+| `resource` | Client ID |
+| `ssl-required` | `none`, `external`, or `all` |
+| `verify-token-audience` | Validate audience claim against `resource` |
+| `credentials.secret` | Client secret (confidential clients) |
+
+Both kebab-case (Keycloak adapter format) and PascalCase are supported.
+
+## Adding Authorization (RBAC)
+
+```bash
+dotnet add package Keycloak.AuthServices.Authorization
+```
+
+```csharp
+builder.Services.AddKeycloakAuthorization(builder.Configuration)
+    .AddAuthorizationBuilder()
+    .AddPolicy("AdminOnly", policy => policy.RequireRealmRoles("admin"))
+    .AddPolicy("EditorOnly", policy => policy.RequireResourceRoles("editor"));
+```
+
+## Adding Authorization Server (Resource Protection)
+
+```csharp
+builder.Services
+    .AddKeycloakAuthorization()
+    .AddAuthorizationServer(builder.Configuration);
+
+app.MapGet("/workspaces", () => "Hello World!")
+    .RequireProtectedResource("workspaces", "workspace:read");
+```
+
+## Adding Admin SDK
+
+```bash
+dotnet add package Keycloak.AuthServices.Sdk
+```
+
+```csharp
+builder.Services.AddKeycloakAdminHttpClient(builder.Configuration);
+
+app.MapGet("/users", async (IKeycloakUserClient client) =>
+    await client.GetUsers("my-realm"));
+```
+
+## Essential Patterns
+
+- **Configuration section**: defaults to `"Keycloak"`, override via `configSectionName` parameter
+- **IHttpClientBuilder**: all HTTP clients return `IHttpClientBuilder` for resilience, handlers, etc.
+- **Token management**: use `Duende.AccessTokenManagement` for service account tokens
+- **OpenTelemetry**: `AddKeycloakAuthServicesInstrumentation()` for metrics and tracing
+- **Aspire**: `AddKeycloakContainer("keycloak")` + `AddRealm("Test")` for local dev
+
+## Reference Documentation
+
+- [authentication.md](references/authentication.md) — JWT Bearer and OIDC setup, all overloads, adapter file config
+- [authorization.md](references/authorization.md) — RBAC, realm/client roles, role claims transformation
+- [resource-protection.md](references/resource-protection.md) — Authorization Server, Protected Resource Builder, dynamic resources, policy provider
+- [admin-sdk.md](references/admin-sdk.md) — Admin REST API (hand-written + Kiota), access token management
+- [protection-api.md](references/protection-api.md) — UMA Protection API, resource/permission/policy management
+- [devex.md](references/devex.md) — .NET Aspire, templates, OpenTelemetry
+- [configuration.md](references/configuration.md) — All configuration options, naming conventions, adapter file
+- [troubleshooting.md](references/troubleshooting.md) — Common issues, recipes, debugging

--- a/skills/keycloak-auth-services/references/admin-sdk.md
+++ b/skills/keycloak-auth-services/references/admin-sdk.md
@@ -1,0 +1,138 @@
+# Admin REST API SDK
+
+Two client options for the Keycloak Admin REST API:
+
+| Package | Description |
+|---------|-------------|
+| `Keycloak.AuthServices.Sdk` | Hand-written typed clients — high quality, partial API coverage |
+| `Keycloak.AuthServices.Sdk.Kiota` | Kiota-generated client — full API coverage |
+
+## Hand-Written SDK
+
+```bash
+dotnet add package Keycloak.AuthServices.Sdk
+```
+
+### Registration
+
+```csharp
+builder.Services.AddKeycloakAdminHttpClient(builder.Configuration);
+```
+
+Registers: `IKeycloakClient` (umbrella), `IKeycloakRealmClient`, `IKeycloakUserClient`, `IKeycloakGroupClient`.
+
+Returns `IHttpClientBuilder` for resilience and handler configuration:
+
+```csharp
+builder.Services
+    .AddKeycloakAdminHttpClient(builder.Configuration)
+    .AddStandardResilienceHandler()
+    .AddHttpMessageHandler<TimingHandler>();
+```
+
+### Available Clients
+
+- `IKeycloakRealmClient` — realm CRUD, export
+- `IKeycloakUserClient` — user CRUD, roles, groups, credentials, sessions
+- `IKeycloakGroupClient` — group CRUD, members
+- `IKeycloakClient` — umbrella interface combining all above
+
+### Usage
+
+```csharp
+app.MapGet("/users", async (IKeycloakUserClient client) =>
+    await client.GetUsers("my-realm"));
+
+app.MapGet("/realm", async (IKeycloakRealmClient client) =>
+    await client.GetRealmAsync("my-realm"));
+```
+
+### Console App
+
+```csharp
+var services = new ServiceCollection();
+
+var keycloakOptions = new KeycloakAdminClientOptions
+{
+    AuthServerUrl = "http://localhost:8080/",
+    Realm = "master",
+    Resource = "admin-api",
+};
+services.AddKeycloakAdminHttpClient(keycloakOptions);
+
+var sp = services.BuildServiceProvider();
+var client = sp.GetRequiredService<IKeycloakClient>();
+var realm = await client.GetRealmAsync("Test");
+```
+
+## Kiota-Generated Client
+
+```bash
+dotnet add package Keycloak.AuthServices.Sdk.Kiota
+```
+
+### Registration
+
+```csharp
+builder.Services.AddKeycloakAdminHttpClient(builder.Configuration);
+```
+
+Registers `KeycloakAdminApiClient` — a fluent, fully-typed client generated from OpenAPI spec.
+
+### Usage
+
+```csharp
+var client = sp.GetRequiredService<KeycloakAdminApiClient>();
+var realm = await client.Admin.Realms["Test"].GetAsync();
+var users = await client.Admin.Realms["Test"].Users.GetAsync();
+```
+
+## Access Token Management
+
+Admin API requires authentication. Use `Duende.AccessTokenManagement` for service account tokens:
+
+```bash
+dotnet add package Duende.AccessTokenManagement
+```
+
+### Service Account Setup
+
+1. Create client `"admin-api"` in **master** realm with Client Authentication + Service Account Roles enabled
+2. Add Audience Mapper for `"security-admin-console"`
+3. Assign Service Account Role: `"admin"`
+
+### Configuration
+
+```json
+{
+  "Keycloak": {
+    "realm": "master",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "admin-api",
+    "credentials": {
+      "secret": "your-client-secret"
+    }
+  }
+}
+```
+
+### Token Management Integration
+
+```csharp
+builder.Services.AddDistributedMemoryCache();
+builder.Services.AddClientCredentialsTokenManagement()
+    .AddClient("keycloak", client =>
+    {
+        var keycloakOptions = builder.Configuration
+            .GetKeycloakOptions<KeycloakAdminClientOptions>()!;
+        client.ClientId = keycloakOptions.Resource;
+        client.ClientSecret = keycloakOptions.Credentials?.Secret;
+        client.TokenEndpoint = $"{keycloakOptions.AuthServerUrl.TrimEnd('/')}" +
+            $"/realms/{keycloakOptions.Realm}/protocol/openid-connect/token";
+    });
+
+builder.Services
+    .AddKeycloakAdminHttpClient(builder.Configuration)
+    .AddClientCredentialsTokenHandler("keycloak");
+```

--- a/skills/keycloak-auth-services/references/authentication.md
+++ b/skills/keycloak-auth-services/references/authentication.md
@@ -1,0 +1,178 @@
+# Authentication
+
+## JWT Bearer (Web API)
+
+`AddKeycloakWebApiAuthentication` configures JWT Bearer authentication from the `"Keycloak"` config section.
+
+What it does:
+- Adds and configures `AddJwtBearer` based on Keycloak config
+- Registers `IOptions<KeycloakAuthenticationOptions>` and `IOptions<JwtBearerOptions>`
+
+### ServiceCollection Extensions
+
+From configuration (default `"Keycloak"` section):
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(builder.Configuration);
+```
+
+With explicit section name:
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration,
+    configSectionName: "MyKeycloak"
+);
+```
+
+With `IConfigurationSection`:
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration.GetSection("MyKeycloak")
+);
+```
+
+With inline `JwtBearerOptions` overrides:
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration,
+    jwtBearerOptions =>
+    {
+        jwtBearerOptions.RequireHttpsMetadata = false;
+        jwtBearerOptions.Audience = "my-custom-audience";
+    }
+);
+```
+
+### AuthenticationBuilder Extensions
+
+For custom authentication scheme or more verbose setup:
+
+```csharp
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddKeycloakWebApi(builder.Configuration);
+```
+
+Inline configuration:
+
+```csharp
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddKeycloakWebApi(
+        options =>
+        {
+            options.Resource = "test-client";
+            options.Realm = "Test";
+            options.AuthServerUrl = "http://localhost:8080/";
+            options.VerifyTokenAudience = false;
+        },
+        jwtBearerOptions =>
+        {
+            jwtBearerOptions.RequireHttpsMetadata = false;
+        }
+    );
+```
+
+### Configuration Precedence
+
+`KeycloakAuthenticationOptions` (`"Keycloak"` section) takes precedence over `Authentication:Schemes:{SchemeName}` (`"Bearer"` — `JwtBearerOptions`) in default config.
+
+You can also use ASP.NET Core's standard config:
+
+```json
+{
+  "Keycloak": {
+    "ssl-required": "internal",
+    "resource": "test-client",
+    "verify-token-audience": true,
+    "credentials": { "secret": "secret" }
+  },
+  "Authentication": {
+    "DefaultScheme": "Bearer",
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": ["my-audience"],
+        "RequireHttpsMetadata": true,
+        "Authority": "http://localhost:8080/realms/Test",
+        "TokenValidationParameters": {
+          "ValidateAudience": false
+        }
+      }
+    }
+  }
+}
+```
+
+## OpenID Connect (Web App)
+
+`AddKeycloakWebAppAuthentication` configures OIDC + Cookie authentication for server-rendered web apps (MVC, Razor Pages).
+
+What it does:
+- Adds and configures `OpenIdConnect` based on Keycloak config
+- Registers `IOptions<KeycloakAuthenticationOptions>`, `IOptions<OpenIdConnectOptions>`, `IOptions<CookieAuthenticationOptions>`
+
+### ServiceCollection Extensions
+
+```csharp
+builder.Services.AddKeycloakWebAppAuthentication(builder.Configuration);
+```
+
+### AuthenticationBuilder Extensions
+
+```csharp
+builder.Services
+    .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddKeycloakWebApp(builder.Configuration);
+```
+
+Inline:
+
+```csharp
+builder.Services
+    .AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddKeycloakWebApp(
+        configureKeycloakOptions: options =>
+        {
+            options.Resource = "webapp-client";
+            options.Realm = "Test";
+            options.AuthServerUrl = "http://localhost:8080/";
+        },
+        configureOpenIdConnectOptions: oidcOptions =>
+        {
+            oidcOptions.SaveTokens = true;
+        }
+    );
+```
+
+## Adapter File Configuration Provider
+
+Use a standalone `keycloak.json` file instead of `appsettings.json`:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.ConfigureKeycloakConfigurationSource("keycloak.json");
+
+builder.Services.AddKeycloakWebApiAuthentication(builder.Configuration);
+```
+
+```json
+// keycloak.json
+{
+  "realm": "Test",
+  "auth-server-url": "http://localhost:8088/",
+  "ssl-required": "external",
+  "resource": "test-client",
+  "verify-token-audience": true
+}
+```
+
+## Audience Mapper
+
+By default, `Keycloak.AuthServices.Authentication` validates that the token audience matches the `resource` (client ID). If you get **401 Unauthorized**, either:
+
+1. Configure an Audience Mapper in Keycloak (Client → Client Scopes → `{client_id}-dedicated` → Mappers → Add "Audience" mapper)
+2. Or disable audience validation: `verify-token-audience: false`

--- a/skills/keycloak-auth-services/references/authorization.md
+++ b/skills/keycloak-auth-services/references/authorization.md
@@ -1,0 +1,121 @@
+# Authorization (RBAC)
+
+Role-Based Access Control using Keycloak realm roles and client (resource) roles.
+
+## Setup
+
+```bash
+dotnet add package Keycloak.AuthServices.Authorization
+```
+
+```csharp
+builder.Services.AddKeycloakAuthorization(builder.Configuration);
+```
+
+## Require Realm Roles
+
+Realm roles are global roles that apply to the entire Keycloak realm.
+
+```csharp
+builder.Services.AddKeycloakAuthorization(builder.Configuration)
+    .AddAuthorizationBuilder()
+    .AddPolicy("AdminOnly", policy => policy.RequireRealmRoles("admin"));
+```
+
+## Require Resource (Client) Roles
+
+Resource roles are scoped to a specific client.
+
+With explicit client name:
+
+```csharp
+builder.Services.AddKeycloakAuthorization(builder.Configuration)
+    .AddAuthorizationBuilder()
+    .AddPolicy("EditorOnly", policy =>
+        policy.RequireResourceRoles("editor")); // uses default client from config
+```
+
+The client name is taken from `KeycloakAuthorizationOptions.Resource` in config:
+
+```json
+{
+  "Keycloak": {
+    "resource": "test-client"
+  }
+}
+```
+
+Override default source with `RolesResource`:
+
+```csharp
+builder.Services.AddKeycloakAuthorization(options =>
+{
+    options.RolesResource = "other-client";
+});
+```
+
+## Keycloak Role Claims Transformation
+
+Map Keycloak roles to standard ASP.NET Core role claims. **Disabled by default.**
+
+Enable via configuration:
+
+```json
+{
+  "Keycloak": {
+    "EnableRolesMapping": "Realm"
+  }
+}
+```
+
+Or inline:
+
+```csharp
+builder.Services.AddKeycloakAuthorization(options =>
+{
+    options.EnableRolesMapping = RolesClaimTransformationSource.All;
+    options.RolesResource = "test-client";
+});
+```
+
+### Mapping Sources
+
+| `EnableRolesMapping` | `RolesResource` | Source |
+|---------------------|-----------------|--------|
+| `Realm` | N/A | `token.realm_access.roles` |
+| `ResourceAccess` | `test-client` | `token.resource_access.test-client.roles` |
+| `All` | `test-client` | Both realm + resource roles combined |
+
+Once mapped, use standard ASP.NET Core role-based authorization:
+
+```csharp
+builder.Services.AddAuthorizationBuilder()
+    .AddPolicy("AdminOnly", policy => policy.RequireRole("admin"));
+```
+
+### Target Claim Type
+
+The target claim type defaults to `"role"`. Override with:
+
+```csharp
+options.RoleClaimType = ClaimTypes.Role;
+```
+
+## JWT Token Structure
+
+Keycloak JWT tokens contain roles in two locations:
+
+```json
+{
+  "realm_access": {
+    "roles": ["default-roles-test", "offline_access", "uma_authorization"]
+  },
+  "resource_access": {
+    "test-client": {
+      "roles": ["manage-account", "view-profile"]
+    }
+  }
+}
+```
+
+`RequireRealmRoles` checks `realm_access.roles`, `RequireResourceRoles` checks `resource_access.{client}.roles`.

--- a/skills/keycloak-auth-services/references/configuration.md
+++ b/skills/keycloak-auth-services/references/configuration.md
@@ -1,0 +1,154 @@
+# Configuration Reference
+
+## Configuration Section
+
+All Keycloak.AuthServices packages bind to a `"Keycloak"` config section by default. Override with the `configSectionName` parameter.
+
+## KeycloakAuthenticationOptions
+
+Used by `Keycloak.AuthServices.Authentication`:
+
+```json
+{
+  "Keycloak": {
+    "realm": "Test",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "test-client",
+    "verify-token-audience": true,
+    "confidential-port": 0,
+    "credentials": {
+      "secret": "your-secret"
+    }
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `realm` | string | Realm name |
+| `auth-server-url` | string | Keycloak base URL |
+| `ssl-required` | string | `none` / `external` / `all` |
+| `resource` | string | Client ID (also used as audience) |
+| `verify-token-audience` | bool | Validate `aud` claim matches `resource` |
+| `credentials.secret` | string | Client secret for confidential clients |
+| `confidential-port` | int | HTTPS port (rarely needed) |
+
+## KeycloakAuthorizationOptions
+
+Used by `Keycloak.AuthServices.Authorization`:
+
+```json
+{
+  "Keycloak": {
+    "resource": "test-client",
+    "EnableRolesMapping": "None",
+    "RolesResource": "test-client",
+    "RoleClaimType": "role"
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `resource` | string | Default client for role lookups |
+| `EnableRolesMapping` | enum | `None` / `Realm` / `ResourceAccess` / `All` |
+| `RolesResource` | string | Override client for resource role mapping |
+| `RoleClaimType` | string | Target claim type for mapped roles (default: `"role"`) |
+
+## KeycloakAdminClientOptions
+
+Used by `Keycloak.AuthServices.Sdk` (Admin API):
+
+```json
+{
+  "Keycloak": {
+    "realm": "master",
+    "auth-server-url": "http://localhost:8080/",
+    "resource": "admin-api",
+    "credentials": {
+      "secret": "your-secret"
+    }
+  }
+}
+```
+
+## KeycloakProtectionClientOptions
+
+Used by `Keycloak.AuthServices.Sdk` (Protection API):
+
+```json
+{
+  "Keycloak": {
+    "realm": "my-realm",
+    "auth-server-url": "http://localhost:8080/",
+    "resource": "my-client",
+    "credentials": {
+      "secret": "your-secret"
+    }
+  }
+}
+```
+
+## Naming Conventions
+
+Both kebab-case (Keycloak adapter format) and PascalCase are supported:
+
+```json
+{
+  "Keycloak_kebab": {
+    "realm": "Test",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "test-client",
+    "verify-token-audience": true,
+    "credentials": { "secret": "secret" }
+  },
+  "Keycloak_pascal": {
+    "Realm": "Test",
+    "AuthServerUrl": "http://localhost:8080/",
+    "SslRequired": "none",
+    "Resource": "test-client",
+    "VerifyTokenAudience": true,
+    "Credentials": { "Secret": "secret" }
+  }
+}
+```
+
+Default format is kebab-case (matching Keycloak's adapter config download).
+
+## Adapter File
+
+Instead of `appsettings.json`, use a standalone `keycloak.json`:
+
+```csharp
+builder.Host.ConfigureKeycloakConfigurationSource("keycloak.json");
+```
+
+## Resolving Options
+
+From DI:
+
+```csharp
+// Authentication options (named, per scheme)
+var authOptions = serviceProvider
+    .GetRequiredService<IOptionsMonitor<KeycloakAuthenticationOptions>>()
+    .Get(JwtBearerDefaults.AuthenticationScheme);
+
+// Authorization options
+var authzOptions = serviceProvider
+    .GetRequiredService<IOptionsMonitor<KeycloakAuthorizationOptions>>()
+    .CurrentValue;
+```
+
+Before DI is built (at startup):
+
+```csharp
+using Keycloak.AuthServices.Common;
+
+var options = configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
+
+// Or bind manually:
+KeycloakAuthorizationOptions options = new();
+configuration.BindKeycloakOptions(options);
+```

--- a/skills/keycloak-auth-services/references/devex.md
+++ b/skills/keycloak-auth-services/references/devex.md
@@ -1,0 +1,140 @@
+# Developer Experience
+
+## .NET Aspire Integration
+
+```bash
+dotnet add package Keycloak.AuthServices.Aspire.Hosting
+```
+
+### AppHost Setup
+
+```csharp
+// AppHost/Program.cs
+var builder = DistributedApplication.CreateBuilder(args);
+
+var keycloak = builder.AddKeycloakContainer("keycloak");
+var realm = keycloak.AddRealm("Test");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(keycloak)
+    .WithReference(realm);
+
+builder.Build().Run();
+```
+
+What this does:
+1. Starts Keycloak as Docker container
+2. `WithReference(keycloak)` — adds Keycloak to Service Discovery
+3. `WithReference(realm)` — sets `Keycloak__Realm` and `Keycloak__AuthServerUrl` env vars
+
+### Import Configuration Files
+
+```csharp
+var keycloak = builder
+    .AddKeycloakContainer("keycloak")
+    .WithDataVolume()
+    .WithImport("./KeycloakConfiguration/Test-realm.json")
+    .WithImport("./KeycloakConfiguration/Test-users-0.json");
+```
+
+Export current config from inside the container:
+
+```bash
+/opt/keycloak/bin/kc.sh export --dir /opt/keycloak/data/import --realm Test
+```
+
+### API Project Configuration
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
+
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration,
+    options =>
+    {
+        options.Audience = "workspaces-client";
+        options.RequireHttpsMetadata = false;
+    }
+);
+builder.Services.AddAuthorization();
+```
+
+## Project Templates
+
+```bash
+dotnet new install Keycloak.AuthServices.Templates
+```
+
+### Available Templates
+
+| Template | Short Name | Description |
+|----------|-----------|-------------|
+| Keycloak WebApi | `keycloak-webapi` | Single Web API project with Keycloak auth |
+| Keycloak Aspire Starter | `keycloak-aspire-starter` | Full Aspire solution with Keycloak |
+
+### Web API Template
+
+```bash
+dotnet new keycloak-webapi -o MyKeycloakApi
+```
+
+Creates: `Program.cs`, `appsettings.json`, OpenAPI config, `Directory.Build.props`.
+
+### Aspire Template
+
+```bash
+dotnet new keycloak-aspire-starter -o MyAspireSolution --EnableKeycloakImport
+```
+
+Creates full solution: AppHost, API, ServiceDefaults, with optional realm import files.
+
+## OpenTelemetry
+
+```bash
+dotnet add package Keycloak.AuthServices.OpenTelemetry
+```
+
+```csharp
+builder.Services
+    .AddOpenTelemetry()
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddKeycloakAuthServicesInstrumentation()
+    )
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddHttpClientInstrumentation()
+        .AddKeycloakAuthServicesInstrumentation()
+    )
+    .UseOtlpExporter();
+```
+
+### Metrics
+
+Monitor authorization decisions:
+
+```bash
+dotnet counters monitor --name MyApp --counters Keycloak.AuthServices.Authorization
+```
+
+```text
+[Keycloak.AuthServices.Authorization]
+    keycloak.authservices.requirements.fail (Count)
+        requirement=ParameterizedProtectedResourceRequirement    3
+    keycloak.authservices.requirements.succeed (Count)
+        requirement=ParameterizedProtectedResourceRequirement    5
+        requirement=RealmAccessRequirement                      16
+```
+
+## Logging
+
+```json
+{
+  "Logging": {
+    "Keycloak.AuthServices": "Debug",
+    "Keycloak.AuthServices.Authorization": "Trace"
+  }
+}
+```

--- a/skills/keycloak-auth-services/references/protection-api.md
+++ b/skills/keycloak-auth-services/references/protection-api.md
@@ -1,0 +1,76 @@
+# Protection API SDK
+
+The Protection API provides UMA-compliant endpoints for:
+
+- **Resource Management** — CRUD operations on protected resources
+- **Permission Management** — create permission tickets, manage permission state
+- **Policy API** — manage permissions on behalf of users
+
+## Setup
+
+```bash
+dotnet add package Keycloak.AuthServices.Sdk
+```
+
+```csharp
+builder.Services.AddKeycloakProtectionHttpClient(builder.Configuration);
+```
+
+Registers `IKeycloakProtectionClient` integrated with `IHttpClientFactory`.
+
+Returns `IHttpClientBuilder` for further configuration:
+
+```csharp
+builder.Services
+    .AddKeycloakProtectionHttpClient(builder.Configuration)
+    .AddStandardResilienceHandler();
+```
+
+## Access Token
+
+Protection API is protected — requires authentication. Use the same token management approach as Admin SDK:
+
+```csharp
+builder.Services
+    .AddKeycloakProtectionHttpClient(builder.Configuration)
+    .AddClientCredentialsTokenHandler("keycloak");
+```
+
+## Available Operations
+
+### Resource Management
+
+```csharp
+// List resources
+var resources = await protectionClient.GetResourcesAsync("my-realm");
+
+// Get resource by ID
+var resource = await protectionClient.GetResourceAsync("my-realm", resourceId);
+
+// Create resource
+await protectionClient.CreateResourceAsync("my-realm", new Resource
+{
+    Name = "my-resource",
+    Type = "urn:my-type",
+    Scopes = new[] { new Scope { Name = "read" }, new Scope { Name = "write" } }
+});
+```
+
+### Policy Management
+
+```csharp
+// List policies
+var policies = await protectionClient.GetPoliciesAsync("my-realm");
+
+// Get policy by ID
+var policy = await protectionClient.GetPolicyAsync("my-realm", policyId);
+```
+
+## Distinction: Protection API vs Authorization Server
+
+| Feature | Protection API (`IKeycloakProtectionClient`) | Authorization Server (`IAuthorizationServerClient`) |
+|---------|----------------------------------------------|-----------------------------------------------------|
+| Purpose | Manage resources, permissions, policies | Evaluate permissions at runtime |
+| Package | `Keycloak.AuthServices.Sdk` | `Keycloak.AuthServices.Authorization` |
+| Used by | Backend services managing Keycloak config | Web APIs protecting endpoints |
+| Auth | Service account token | User's access token (header propagation) |

--- a/skills/keycloak-auth-services/references/resource-protection.md
+++ b/skills/keycloak-auth-services/references/resource-protection.md
@@ -1,0 +1,151 @@
+# Resource Protection & Authorization Server
+
+Fine-grained access control using Keycloak Authorization Server. Delegates authorization decisions to Keycloak (PDP) while your app acts as PEP.
+
+## Concepts
+
+- **Resource**: entity to protect (e.g., "my-workspace")
+- **Scope**: action on resource (e.g., "workspace:read", "workspace:write")
+- **Permission**: rule linking resource + scope + policy
+- **Policy**: condition evaluated by Keycloak (role-based, time-based, etc.)
+- **PEP** (Policy Enforcement Point): your app — intercepts requests, checks authorization
+- **PDP** (Policy Decision Point): Keycloak Authorization Server — evaluates policies
+
+## Setup
+
+```bash
+dotnet add package Keycloak.AuthServices.Authorization
+```
+
+```csharp
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddKeycloakWebApi(builder.Configuration);
+
+builder.Services
+    .AddAuthorization()
+    .AddKeycloakAuthorization()
+    .AddAuthorizationServer(builder.Configuration);
+```
+
+Authorization Server calls are made on behalf of the user via header propagation. `AddAuthorizationServer` adds `AccessTokenPropagationHandler` that reads the user's JWT from `IHttpContextAccessor`.
+
+## Protected Resource Builder
+
+Simplest way to protect endpoints — no manual policy registration:
+
+```csharp
+app.MapGet("/workspaces", () => "Hello World!")
+    .RequireProtectedResource("workspaces", "workspace:read");
+```
+
+`RequireProtectedResource` is an extension on `IEndpointConventionBuilder` — works with Minimal APIs, MVC, RazorPages.
+
+### Dynamic Resources
+
+Use path parameters in resource names:
+
+```csharp
+app.MapGet("/workspaces/{id}", (string id) => $"Workspace {id}")
+    .RequireProtectedResource("workspaces/{id}", "workspace:read");
+```
+
+The `{id}` placeholder is resolved from the route parameter at runtime.
+
+### Multiple Scopes
+
+```csharp
+app.MapDelete("/workspaces/{id}", (string id) => Results.NoContent())
+    .RequireProtectedResource("workspaces/{id}", "workspace:read", "workspace:delete");
+```
+
+### Endpoint Hierarchy (Group-level + Endpoint-level)
+
+```csharp
+var workspaces = app.MapGroup("/workspaces")
+    .RequireProtectedResource("workspaces", "workspace:read");
+
+workspaces.MapGet("/", () => "List");
+workspaces.MapDelete("/{id}", (string id) => Results.NoContent())
+    .RequireProtectedResource("workspaces/{id}", "workspace:delete");
+```
+
+### Multiple Resources
+
+```csharp
+app.MapGet("/dashboard", () => "Dashboard")
+    .RequireProtectedResource("workspaces", "workspace:read")
+    .RequireProtectedResource("reports", "report:view");
+```
+
+### Ignore Protected Resources
+
+Similar to `AllowAnonymous`:
+
+```csharp
+var group = app.MapGroup("/workspaces")
+    .RequireProtectedResource("workspaces", "workspace:read");
+
+group.MapGet("/public", () => "Public")
+    .IgnoreProtectedResources();
+```
+
+## Policy-Based Approach
+
+Instead of Protected Resource Builder, use standard ASP.NET policies:
+
+```csharp
+builder.Services
+    .AddKeycloakAuthorization()
+    .AddAuthorizationServer(builder.Configuration)
+    .AddAuthorizationBuilder()
+    .AddPolicy("WorkspaceRead", policy =>
+        policy.RequireProtectedResource(
+            resource: "workspaces",
+            scope: "workspace:read"
+        )
+    );
+
+app.MapGet("/workspaces", () => "Hello").RequireAuthorization("WorkspaceRead");
+```
+
+## Policy Provider (Convention-Based)
+
+Auto-register policies from naming convention `<resource>#<scope1>,<scope2>`:
+
+```csharp
+builder.Services.AddAuthorizationServer(options =>
+{
+    builder.Configuration.BindKeycloakOptions(options);
+    options.UseProtectedResourcePolicyProvider = true;
+});
+
+app.MapGet("/", () => "Hello")
+    .RequireAuthorization("my-workspace#workspaces:read");
+```
+
+## ProtectedResource Attribute (Controllers)
+
+```csharp
+[ProtectedResource("documents", "read")]
+public class DocumentsController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() => Ok("Documents");
+
+    [HttpDelete("{id}")]
+    [ProtectedResource("documents/{id}", "delete")]
+    public IActionResult Delete(string id) => NoContent();
+}
+```
+
+## Keycloak Configuration
+
+1. Enable Authorization on the client in Keycloak admin console
+2. Create Resources (e.g., "workspaces" with type "urn:workspaces")
+3. Create Scopes (e.g., "workspace:read", "workspace:write")
+4. Create Policies (e.g., "Require Admin Role" — role-based policy)
+5. Create Permissions linking resources + scopes + policies
+6. Use Keycloak's "Evaluate" tab to test permissions
+
+See realm export files in `tests/Keycloak.AuthServices.IntegrationTests/KeycloakConfiguration/` for complete working examples.

--- a/skills/keycloak-auth-services/references/troubleshooting.md
+++ b/skills/keycloak-auth-services/references/troubleshooting.md
@@ -1,0 +1,116 @@
+# Troubleshooting & Recipes
+
+## Common Issues
+
+### 401 Unauthorized
+
+1. Enable debug logging: `"Keycloak.AuthServices": "Debug"`
+2. Verify access token is in the `Authorization: Bearer <token>` header
+3. Check audience mapper — token `aud` must include your `resource` (client ID). Either:
+   - Add Audience Mapper in Keycloak (Client → Client Scopes → `{client_id}-dedicated` → Mappers → Audience)
+   - Or set `"verify-token-audience": false`
+4. For dev: ensure `"ssl-required": "none"` and HTTPS metadata is not required
+
+### 403 Forbidden
+
+1. Enable trace logging: `"Keycloak.AuthServices.Authorization": "Trace"`
+2. For RBAC: verify `ClaimsPrincipal` has `realm_access` and `resource_access` claims
+3. For Authorization Server: ensure Keycloak is accessible and client has Authorization enabled
+4. Check policy evaluation in Keycloak admin → Authorization → Evaluate tab
+
+### Keycloak Slow to Respond
+
+- Keycloak becomes bottleneck in Authorization Server scenarios
+- Add resilience handlers: `.AddStandardResilienceHandler()`
+- Consider cluster setup for production
+- Use OpenTelemetry to identify bottlenecks
+
+## Recipes
+
+### Debug Logging
+
+```json
+{
+  "Logging": {
+    "Keycloak.AuthServices": "Debug",
+    "Keycloak.AuthServices.Authorization": "Trace"
+  }
+}
+```
+
+### Get Options from DI
+
+```csharp
+// Authentication (named options, per scheme)
+var authOptions = sp.GetRequiredService<IOptionsMonitor<KeycloakAuthenticationOptions>>()
+    .Get(JwtBearerDefaults.AuthenticationScheme);
+
+// Authorization
+var authzOptions = sp.GetRequiredService<IOptionsMonitor<KeycloakAuthorizationOptions>>()
+    .CurrentValue;
+```
+
+### Get Options Before DI Is Built
+
+```csharp
+using Keycloak.AuthServices.Common;
+
+var options = configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
+```
+
+### Swagger UI with Keycloak
+
+Using NSwag:
+
+```csharp
+builder.Services.AddOpenApiDocument((document, sp) =>
+{
+    var keycloakOptions = sp
+        .GetRequiredService<IOptionsMonitor<KeycloakAuthenticationOptions>>()
+        ?.Get(JwtBearerDefaults.AuthenticationScheme)!;
+
+    document.AddSecurity(
+        OpenIdConnectDefaults.AuthenticationScheme,
+        [],
+        new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.OpenIdConnect,
+            OpenIdConnectUrl = keycloakOptions.OpenIdConnectUrl,
+        }
+    );
+
+    document.OperationProcessors.Add(
+        new OperationSecurityScopeProcessor(OpenIdConnectDefaults.AuthenticationScheme)
+    );
+});
+
+app.UseSwaggerUi(ui =>
+{
+    var opts = builder.Configuration
+        .GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
+    ui.OAuth2Client = new OAuth2ClientSettings
+    {
+        ClientId = opts.Resource,
+        ClientSecret = opts.Credentials?.Secret,
+    };
+});
+```
+
+### HTTP Client Resilience
+
+Globally (all HTTP clients):
+
+```csharp
+builder.Services.ConfigureHttpClientDefaults(http =>
+    http.AddStandardResilienceHandler());
+```
+
+Per client:
+
+```csharp
+builder.Services
+    .AddKeycloakAuthorization()
+    .AddAuthorizationServer(builder.Configuration)
+    .AddStandardResilienceHandler();
+```
+


### PR DESCRIPTION
## Summary

- Add `keycloak-auth-services` Claude Code plugin skill — implementation guide for the Keycloak.AuthServices .NET library
- SKILL.md with quick-start router and 8 reference docs covering authentication (JWT Bearer, OIDC), authorization (RBAC, resource protection), Admin REST API SDK, Protection API, and developer experience (Aspire, templates, OpenTelemetry)
- Update `README-plugin.md` to list both skills

## Test plan

- [x] Verified both kebab-case and PascalCase config conventions pass tests (`KeycloakInstallationOptionsTests`)
- [x] `dotnet build` succeeds
- [x] Install plugin locally and verify `/keycloak-authservices:keycloak-auth-services` skill loads