### PR TITLE
feat: add pluggable parameter resolution for protected resource authorization

### DIFF
--- a/src/Keycloak.AuthServices.Authorization/HeaderParameterResolver.cs
+++ b/src/Keycloak.AuthServices.Authorization/HeaderParameterResolver.cs
@@ -1,0 +1,16 @@
+namespace Keycloak.AuthServices.Authorization;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Resolves parameters from HTTP request headers.
+/// </summary>
+public sealed class HeaderParameterResolver : IParameterResolver
+{
+    /// <inheritdoc/>
+    public string? Resolve(
+        string parameter,
+        HttpContext httpContext,
+        IServiceProvider serviceProvider
+    ) => httpContext.Request.Headers[parameter].FirstOrDefault();
+}

--- a/src/Keycloak.AuthServices.Authorization/IParameterResolver.cs
+++ b/src/Keycloak.AuthServices.Authorization/IParameterResolver.cs
@@ -1,0 +1,18 @@
+namespace Keycloak.AuthServices.Authorization;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Resolves parameter values from a request context for protected resource templates.
+/// </summary>
+public interface IParameterResolver
+{
+    /// <summary>
+    /// Resolves the value of a named parameter from the current request context.
+    /// </summary>
+    /// <param name="parameter">The parameter name extracted from the resource template (e.g., "workspaceId" from "{workspaceId}").</param>
+    /// <param name="httpContext">The current HTTP context.</param>
+    /// <param name="serviceProvider">The request-scoped service provider.</param>
+    /// <returns>The resolved parameter value, or <c>null</c> if the parameter could not be resolved.</returns>
+    public string? Resolve(string parameter, HttpContext httpContext, IServiceProvider serviceProvider);
+}

--- a/src/Keycloak.AuthServices.Authorization/IProtectedResourceData.cs
+++ b/src/Keycloak.AuthServices.Authorization/IProtectedResourceData.cs
@@ -8,12 +8,18 @@ public interface IProtectedResourceData
     /// <summary>
     /// Gets or sets resource name
     /// </summary>
-    string Resource { get; }
+    public string Resource { get; }
 
     /// <summary>
     /// Get or sets scopes
     /// </summary>
-    string[]? Scopes { get; }
+    public string[]? Scopes { get; }
+
+    /// <summary>
+    /// Gets the type of <see cref="IParameterResolver"/> used to resolve resource template parameters.
+    /// When <c>null</c>, the default <c>RouteParameterResolver</c> is used.
+    /// </summary>
+    public Type? ResolverType => null;
 
     /// <summary>
     /// </summary>

--- a/src/Keycloak.AuthServices.Authorization/Keycloak.AuthServices.Authorization.csproj
+++ b/src/Keycloak.AuthServices.Authorization/Keycloak.AuthServices.Authorization.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Keycloak.AuthServices.Authorization.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Keycloak.AuthServices.Common\Keycloak.AuthServices.Common.csproj" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Keycloak.AuthServices.Authorization/ProtectedResourceAttribute.cs
+++ b/src/Keycloak.AuthServices.Authorization/ProtectedResourceAttribute.cs
@@ -3,32 +3,33 @@ namespace Keycloak.AuthServices.Authorization;
 /// <summary>
 /// Specifies that the class or method that this attribute is applied to requires the specified authorization.
 /// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ProtectedResourceAttribute"/> class with the specified policy.
+/// </remarks>
 [AttributeUsage(
     AttributeTargets.Class | AttributeTargets.Method,
     AllowMultiple = true,
     Inherited = true
 )]
-public sealed class ProtectedResourceAttribute : Attribute, IProtectedResourceData
+public sealed class ProtectedResourceAttribute(string resource, string[] scopes)
+    : Attribute,
+        IProtectedResourceData
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ProtectedResourceAttribute"/> class with the specified policy.
     /// </summary>
     public ProtectedResourceAttribute(string resource, string? scope = default)
-        : this(resource, string.IsNullOrWhiteSpace(scope) ? Array.Empty<string>() : new[] { scope })
-    { }
+        : this(resource, string.IsNullOrWhiteSpace(scope) ? [] : [scope]) { }
+
+    /// <inheritdoc/>
+    public string Resource { get; } = resource;
+
+    /// <inheritdoc/>
+    public string[]? Scopes { get; } = scopes;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProtectedResourceAttribute"/> class with the specified policy.
+    /// Gets or sets the type of <see cref="IParameterResolver"/> used to resolve resource template parameters.
+    /// When <c>null</c>, the default <c>RouteParameterResolver</c> is used.
     /// </summary>
-    public ProtectedResourceAttribute(string resource, string[] scopes)
-    {
-        this.Resource = resource;
-        this.Scopes = scopes;
-    }
-
-    /// <inheritdoc/>
-    public string Resource { get; }
-
-    /// <inheritdoc/>
-    public string[]? Scopes { get; }
+    public Type? ResolverType { get; set; }
 }

--- a/src/Keycloak.AuthServices.Authorization/ProtectedResourceEndpointConventionBuilderExtensions.cs
+++ b/src/Keycloak.AuthServices.Authorization/ProtectedResourceEndpointConventionBuilderExtensions.cs
@@ -45,7 +45,7 @@ public static class ProtectedResourceEndpointConventionBuilderExtensions
         string scope
     )
         where TBuilder : IEndpointConventionBuilder =>
-        builder.RequireProtectedResource(resource, new string[] { scope });
+        builder.RequireProtectedResource(resource, [scope]);
 
     /// <summary>
     /// Adds <see cref="ProtectedResourceAttribute"/> to the endpoint(s).
@@ -68,6 +68,85 @@ public static class ProtectedResourceEndpointConventionBuilderExtensions
         RequireAuthorizationCore(
             builder,
             new ProtectedResourceAttribute[] { new(resource, scopes) }
+        );
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds <see cref="ProtectedResourceAttribute"/> to the endpoint(s) with a custom <see cref="IParameterResolver"/>.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of endpoint convention builder.</typeparam>
+    /// <typeparam name="TResolver">The type of <see cref="IParameterResolver"/> to use for resolving resource template parameters.</typeparam>
+    /// <param name="builder">The endpoint convention builder.</param>
+    /// <param name="resource"></param>
+    /// <returns>The original convention builder parameter.</returns>
+    public static TBuilder RequireProtectedResource<TBuilder, TResolver>(
+        this TBuilder builder,
+        string resource
+    )
+        where TBuilder : IEndpointConventionBuilder
+        where TResolver : IParameterResolver
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        RequireAuthorizationCore(
+            builder,
+            new ProtectedResourceAttribute[]
+            {
+                new(resource, string.Empty) { ResolverType = typeof(TResolver) },
+            }
+        );
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds <see cref="ProtectedResourceAttribute"/> to the endpoint(s) with a custom <see cref="IParameterResolver"/>.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of endpoint convention builder.</typeparam>
+    /// <typeparam name="TResolver">The type of <see cref="IParameterResolver"/> to use for resolving resource template parameters.</typeparam>
+    /// <param name="builder">The endpoint convention builder.</param>
+    /// <param name="resource"></param>
+    /// <param name="scope"></param>
+    /// <returns>The original convention builder parameter.</returns>
+    public static TBuilder RequireProtectedResource<TBuilder, TResolver>(
+        this TBuilder builder,
+        string resource,
+        string scope
+    )
+        where TBuilder : IEndpointConventionBuilder
+        where TResolver : IParameterResolver =>
+        builder.RequireProtectedResource<TBuilder, TResolver>(resource, new string[] { scope });
+
+    /// <summary>
+    /// Adds <see cref="ProtectedResourceAttribute"/> to the endpoint(s) with a custom <see cref="IParameterResolver"/>.
+    /// </summary>
+    /// <typeparam name="TBuilder">The type of endpoint convention builder.</typeparam>
+    /// <typeparam name="TResolver">The type of <see cref="IParameterResolver"/> to use for resolving resource template parameters.</typeparam>
+    /// <param name="builder">The endpoint convention builder.</param>
+    /// <param name="resource"></param>
+    /// <param name="scopes"></param>
+    /// <returns>The original convention builder parameter.</returns>
+    public static TBuilder RequireProtectedResource<TBuilder, TResolver>(
+        this TBuilder builder,
+        string resource,
+        string[] scopes
+    )
+        where TBuilder : IEndpointConventionBuilder
+        where TResolver : IParameterResolver
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(scopes);
+
+        RequireAuthorizationCore(
+            builder,
+            new ProtectedResourceAttribute[]
+            {
+                new(resource, scopes) { ResolverType = typeof(TResolver) },
+            }
         );
 
         return builder;
@@ -100,10 +179,7 @@ public static class ProtectedResourceEndpointConventionBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        RequireAuthorizationCore(
-            builder,
-            new IgnoreProtectedResourceAttribute[] { new() }
-        );
+        RequireAuthorizationCore(builder, new IgnoreProtectedResourceAttribute[] { new() });
 
         return builder;
     }

--- a/src/Keycloak.AuthServices.Authorization/QueryParameterResolver.cs
+++ b/src/Keycloak.AuthServices.Authorization/QueryParameterResolver.cs
@@ -1,0 +1,16 @@
+namespace Keycloak.AuthServices.Authorization;
+
+using Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Resolves parameters from query string values.
+/// </summary>
+public sealed class QueryParameterResolver : IParameterResolver
+{
+    /// <inheritdoc/>
+    public string? Resolve(
+        string parameter,
+        HttpContext httpContext,
+        IServiceProvider serviceProvider
+    ) => httpContext.Request.Query[parameter].FirstOrDefault();
+}

--- a/src/Keycloak.AuthServices.Authorization/Requirements/DecisionRequirement.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/DecisionRequirement.cs
@@ -63,34 +63,31 @@ public class DecisionRequirement : IAuthorizationRequirement, IProtectedResource
 }
 
 /// <summary>
+/// Authorization handler for <see cref="DecisionRequirement"/>
 /// </summary>
-public class DecisionRequirementHandler : AuthorizationHandler<DecisionRequirement>
+/// <param name="client"></param>
+/// <param name="httpContextAccessor"></param>
+/// <param name="serviceProvider"></param>
+/// <param name="metrics"></param>
+/// <param name="logger"></param>
+/// <exception cref="ArgumentNullException"></exception>
+public class DecisionRequirementHandler(
+    IAuthorizationServerClient client,
+    IHttpContextAccessor httpContextAccessor,
+    IServiceProvider serviceProvider,
+    KeycloakMetrics metrics,
+    ILogger<DecisionRequirementHandler> logger
+) : AuthorizationHandler<DecisionRequirement>
 {
-    private readonly IAuthorizationServerClient client;
-    private readonly IHttpContextAccessor httpContextAccessor;
-    private readonly KeycloakMetrics metrics;
-    private readonly ILogger<DecisionRequirementHandler> logger;
-
-    /// <summary>
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="httpContextAccessor"></param>
-    /// <param name="metrics"></param>
-    /// <param name="logger"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public DecisionRequirementHandler(
-        IAuthorizationServerClient client,
-        IHttpContextAccessor httpContextAccessor,
-        KeycloakMetrics metrics,
-        ILogger<DecisionRequirementHandler> logger
-    )
-    {
-        this.client = client ?? throw new ArgumentNullException(nameof(client));
-        this.httpContextAccessor =
-            httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
-        this.metrics = metrics;
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-    }
+    private readonly IAuthorizationServerClient client =
+        client ?? throw new ArgumentNullException(nameof(client));
+    private readonly IHttpContextAccessor httpContextAccessor =
+        httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    private readonly IServiceProvider serviceProvider =
+        serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    private readonly KeycloakMetrics metrics = metrics;
+    private readonly ILogger<DecisionRequirementHandler> logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc/>
     protected override async Task HandleRequirementAsync(
@@ -117,8 +114,9 @@ public class DecisionRequirementHandler : AuthorizationHandler<DecisionRequireme
         }
 
         var resource = Utils.ResolveResource(
-            requirement.Resource,
-            this.httpContextAccessor.HttpContext
+            requirement,
+            this.httpContextAccessor,
+            this.serviceProvider
         );
         this.logger.LogResourceResolved(requirement.Resource, resource);
 

--- a/src/Keycloak.AuthServices.Authorization/Requirements/ParameterizedProtectedResourceRequirement.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/ParameterizedProtectedResourceRequirement.cs
@@ -19,34 +19,32 @@ public class ParameterizedProtectedResourceRequirement : IAuthorizationRequireme
 }
 
 /// <summary>
+/// Authorization handler for <see cref="ParameterizedProtectedResourceRequirement"/>
 /// </summary>
-public class ParameterizedProtectedResourceRequirementHandler
-    : AuthorizationHandler<ParameterizedProtectedResourceRequirement>
+/// <param name="client"></param>
+/// <param name="httpContextAccessor"></param>
+/// <param name="serviceProvider"></param>
+/// <param name="metrics"></param>
+/// <param name="logger"></param>
+/// <exception cref="ArgumentNullException"></exception>
+public class ParameterizedProtectedResourceRequirementHandler(
+    IAuthorizationServerClient client,
+    IHttpContextAccessor httpContextAccessor,
+    IServiceProvider serviceProvider,
+    KeycloakMetrics metrics,
+    ILogger<ParameterizedProtectedResourceRequirementHandler> logger
+) : AuthorizationHandler<ParameterizedProtectedResourceRequirement>
 {
-    private readonly IAuthorizationServerClient client;
-    private readonly IHttpContextAccessor httpContextAccessor;
-    private readonly KeycloakMetrics metrics;
-    private readonly ILogger<ParameterizedProtectedResourceRequirementHandler> logger;
-
-    /// <summary>
-    /// </summary>
-    /// <param name="client"></param>
-    /// <param name="httpContextAccessor"></param>
-    /// <param name="metrics"></param>
-    /// <param name="logger"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public ParameterizedProtectedResourceRequirementHandler(
-        IAuthorizationServerClient client,
-        IHttpContextAccessor httpContextAccessor,
-        KeycloakMetrics metrics,
-        ILogger<ParameterizedProtectedResourceRequirementHandler> logger
-    )
-    {
-        this.client = client;
-        this.httpContextAccessor = httpContextAccessor;
-        this.metrics = metrics;
-        this.logger = logger;
-    }
+    private readonly IAuthorizationServerClient client =
+        client ?? throw new ArgumentNullException(nameof(client));
+    private readonly IHttpContextAccessor httpContextAccessor =
+        httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+    private readonly IServiceProvider serviceProvider =
+        serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    private readonly KeycloakMetrics metrics =
+        metrics ?? throw new ArgumentNullException(nameof(metrics));
+    private readonly ILogger<ParameterizedProtectedResourceRequirementHandler> logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
 
     /// <inheritdoc/>
     protected override async Task HandleRequirementAsync(
@@ -75,8 +73,7 @@ public class ParameterizedProtectedResourceRequirementHandler
         var endpoint = this.httpContextAccessor.HttpContext?.GetEndpoint();
 
         var requirementData =
-            endpoint?.Metadata?.GetOrderedMetadata<IProtectedResourceData>()
-            ?? Array.Empty<IProtectedResourceData>();
+            endpoint?.Metadata?.GetOrderedMetadata<IProtectedResourceData>() ?? [];
 
         var verificationPlan = new VerificationPlan(requirementData);
         this.logger.LogVerificationPlan(verificationPlan.ToString(), userName);
@@ -87,8 +84,9 @@ public class ParameterizedProtectedResourceRequirementHandler
         {
             var scopes = entry.GetScopesExpression();
             var resource = Utils.ResolveResource(
-                entry.Resource,
-                this.httpContextAccessor.HttpContext
+                entry,
+                this.httpContextAccessor,
+                this.serviceProvider
             );
             this.logger.LogResourceResolved(entry.Resource, resource);
 

--- a/src/Keycloak.AuthServices.Authorization/RouteParameterResolver.cs
+++ b/src/Keycloak.AuthServices.Authorization/RouteParameterResolver.cs
@@ -1,0 +1,17 @@
+namespace Keycloak.AuthServices.Authorization;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+/// <summary>
+/// Resolves parameters from route values. This is the default resolver.
+/// </summary>
+internal sealed class RouteParameterResolver : IParameterResolver
+{
+    /// <inheritdoc/>
+    public string? Resolve(
+        string parameter,
+        HttpContext httpContext,
+        IServiceProvider serviceProvider
+    ) => httpContext.GetRouteValue(parameter)?.ToString();
+}

--- a/src/Keycloak.AuthServices.Authorization/ServiceCollectionExtensions.cs
+++ b/src/Keycloak.AuthServices.Authorization/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Requirements;
 
@@ -201,6 +202,10 @@ public static class ServiceCollectionExtensions
         services.Configure(configureKeycloakOptions);
 
         services.AddHttpContextAccessor();
+
+        services.TryAddSingleton<RouteParameterResolver>();
+        services.TryAddSingleton<HeaderParameterResolver>();
+        services.TryAddSingleton<QueryParameterResolver>();
 
         services
             .AddAuthorizationBuilder()

--- a/src/Keycloak.AuthServices.Authorization/Utils.cs
+++ b/src/Keycloak.AuthServices.Authorization/Utils.cs
@@ -1,35 +1,55 @@
 namespace Keycloak.AuthServices.Authorization;
 
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 
-internal static class Utils
+internal static partial class Utils
 {
-    public static string ResolveResource(string resource, HttpContext? httpContext)
+    [GeneratedRegex(@"\{([^}]+)\}")]
+    private static partial Regex ParameterPlaceholderRegex();
+
+    public static string ResolveResource(
+        string resource,
+        HttpContext httpContext,
+        IParameterResolver resolver,
+        IServiceProvider serviceProvider
+    )
     {
-        if (httpContext is null)
+        if (!resource.Contains('{') || !resource.Contains('}'))
         {
             return resource;
         }
 
-        var pathParameters = httpContext.GetRouteData()?.Values;
-
-        if (pathParameters != null && resource.Contains('}') && resource.Contains('{'))
-        {
-            foreach (var parameter in pathParameters)
-            {
-                var parameterName = parameter.Key;
-
-                if (resource.Contains($"{{{parameterName}}}"))
+        return ParameterPlaceholderRegex()
+            .Replace(
+                resource,
+                match =>
                 {
-                    var parameterValue = parameter.Value?.ToString();
-                    resource = resource.Replace($"{{{parameterName}}}", parameterValue);
+                    var parameterName = match.Groups[1].Value;
+                    return resolver.Resolve(parameterName, httpContext, serviceProvider)
+                        ?? match.Value;
                 }
-            }
+            );
+    }
+
+    public static string ResolveResource(
+        IProtectedResourceData resourceData,
+        IHttpContextAccessor httpContextAccessor,
+        IServiceProvider serviceProvider
+    )
+    {
+        var httpContext = httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return resourceData.Resource;
         }
 
-        return resource;
+        var resolverType = resourceData.ResolverType ?? typeof(RouteParameterResolver);
+        var resolver = (IParameterResolver)serviceProvider.GetRequiredService(resolverType);
+
+        return ResolveResource(resourceData.Resource, httpContext, resolver, serviceProvider);
     }
 
     public static bool IsAuthenticated(this ClaimsPrincipal? principal) =>

--- a/tests/Keycloak.AuthServices.Authorization.Tests/ParameterResolverTests.cs
+++ b/tests/Keycloak.AuthServices.Authorization.Tests/ParameterResolverTests.cs
@@ -1,0 +1,268 @@
+namespace Keycloak.AuthServices.Authorization.Tests;
+
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+public class ParameterResolverTests
+{
+    [Fact]
+    public void RouteParameterResolver_ResolvesFromRouteValues()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.RouteValues["workspaceId"] = "123";
+
+        var resolver = new RouteParameterResolver();
+        var result = resolver.Resolve(
+            "workspaceId",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("123");
+    }
+
+    [Fact]
+    public void RouteParameterResolver_ReturnsNull_WhenNotFound()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        var resolver = new RouteParameterResolver();
+        var result = resolver.Resolve(
+            "missing",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void HeaderParameterResolver_ResolvesFromHeaders()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-Tenant-Id"] = "acme";
+
+        var resolver = new HeaderParameterResolver();
+        var result = resolver.Resolve(
+            "X-Tenant-Id",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("acme");
+    }
+
+    [Fact]
+    public void HeaderParameterResolver_ReturnsNull_WhenNotFound()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        var resolver = new HeaderParameterResolver();
+        var result = resolver.Resolve(
+            "X-Tenant-Id",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void QueryParameterResolver_ResolvesFromQueryString()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.QueryString = new QueryString("?tenant=acme");
+
+        var resolver = new QueryParameterResolver();
+        var result = resolver.Resolve(
+            "tenant",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("acme");
+    }
+
+    [Fact]
+    public void QueryParameterResolver_ReturnsNull_WhenNotFound()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        var resolver = new QueryParameterResolver();
+        var result = resolver.Resolve(
+            "tenant",
+            httpContext,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveResource_WithResolver_ReplacesPlaceholders()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-Tenant-Id"] = "acme";
+
+        var resolver = new HeaderParameterResolver();
+        var result = Utils.ResolveResource(
+            "workspaces/{X-Tenant-Id}",
+            httpContext,
+            resolver,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("workspaces/acme");
+    }
+
+    [Fact]
+    public void ResolveResource_WithResolver_PreservesUnresolvablePlaceholders()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        var resolver = new HeaderParameterResolver();
+        var result = Utils.ResolveResource(
+            "workspaces/{X-Tenant-Id}",
+            httpContext,
+            resolver,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("workspaces/{X-Tenant-Id}");
+    }
+
+    [Fact]
+    public void ResolveResource_WithResolver_ReturnsUnchanged_WhenNoPlaceholders()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        var resolver = new HeaderParameterResolver();
+        var result = Utils.ResolveResource(
+            "workspaces/static",
+            httpContext,
+            resolver,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("workspaces/static");
+    }
+
+    [Fact]
+    public void ResolveResource_WithResolver_HandlesMultiplePlaceholders()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-Org"] = "acme";
+        httpContext.Request.Headers["X-Team"] = "engineering";
+
+        var resolver = new HeaderParameterResolver();
+        var result = Utils.ResolveResource(
+            "orgs/{X-Org}/teams/{X-Team}",
+            httpContext,
+            resolver,
+            new ServiceCollection().BuildServiceProvider()
+        );
+
+        result.Should().Be("orgs/acme/teams/engineering");
+    }
+
+    [Fact]
+    public void ResolveResource_UsesRouteResolver_WhenResolverTypeIsNull()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<RouteParameterResolver>();
+        var sp = services.BuildServiceProvider();
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+        httpContextAccessor.HttpContext.Request.RouteValues["id"] = "42";
+
+        var resourceData = new ProtectedResourceAttribute("items/{id}", "read");
+
+        var result = Utils.ResolveResource(resourceData, httpContextAccessor, sp);
+
+        result.Should().Be("items/42");
+    }
+
+    [Fact]
+    public void ResolveResource_UsesSpecifiedResolver()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<HeaderParameterResolver>();
+        var sp = services.BuildServiceProvider();
+
+        var httpContextAccessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext(),
+        };
+        httpContextAccessor.HttpContext!.Request.Headers["X-Tenant-Id"] = "acme";
+
+        var resourceData = new ProtectedResourceAttribute("workspaces/{X-Tenant-Id}", "read")
+        {
+            ResolverType = typeof(HeaderParameterResolver),
+        };
+
+        var result = Utils.ResolveResource(resourceData, httpContextAccessor, sp);
+
+        result.Should().Be("workspaces/acme");
+    }
+
+    [Fact]
+    public void ProtectedResourceAttribute_ResolverType_DefaultsToNull()
+    {
+        var attribute = new ProtectedResourceAttribute("resource", "scope");
+
+        attribute.ResolverType.Should().BeNull();
+    }
+
+    [Fact]
+    public void ProtectedResourceAttribute_ResolverType_CanBeSet()
+    {
+        var attribute = new ProtectedResourceAttribute("resource", "scope")
+        {
+            ResolverType = typeof(HeaderParameterResolver),
+        };
+
+        attribute.ResolverType.Should().Be<HeaderParameterResolver>();
+    }
+
+    [Fact]
+    public void IProtectedResourceData_ResolverType_DefaultsToNull()
+    {
+        IProtectedResourceData data = new ProtectedResourceAttribute("resource", "scope");
+
+        data.ResolverType.Should().BeNull();
+    }
+
+    [Fact]
+    public void CustomResolver_CanAccessServiceProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new TestTenantConfig("resolved-tenant"));
+        var sp = services.BuildServiceProvider();
+
+        var httpContext = new DefaultHttpContext();
+        var resolver = new TestCustomResolver();
+
+        var result = resolver.Resolve("tenant", httpContext, sp);
+
+        result.Should().Be("resolved-tenant");
+    }
+
+    private sealed record TestTenantConfig(string TenantId);
+
+    private sealed class TestCustomResolver : IParameterResolver
+    {
+        public string? Resolve(
+            string parameter,
+            HttpContext httpContext,
+            IServiceProvider serviceProvider
+        )
+        {
+            var config = serviceProvider.GetService<TestTenantConfig>();
+            return config?.TenantId;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `IParameterResolver` interface enabling resource template parameters (`{name}`) to be resolved from sources beyond route values — headers, query strings, or custom logic via `IServiceProvider`
- Built-in resolvers: `RouteParameterResolver` (default, internal), `HeaderParameterResolver`, `QueryParameterResolver`
- `ResolverType` property on `IProtectedResourceData` (backward-compatible default interface member) and `ProtectedResourceAttribute`
- Generic `RequireProtectedResource<TBuilder, TResolver>()` endpoint builder overloads for per-endpoint resolver selection
- Updated `DecisionRequirementHandler` and `ParameterizedProtectedResourceRequirementHandler` to use resolver-based resolution
- Registered built-in resolvers as singletons in `AddAuthorizationServer()`

### Usage examples

```csharp
// Default: route values (unchanged behavior)
app.MapGet("/workspaces/{workspaceId}/docs", handler)
    .RequireProtectedResource("workspaces/{workspaceId}", "read");

// Header-based tenant resolution
app.MapGet("/docs", handler)
    .RequireProtectedResource<RouteEndpointBuilder, HeaderParameterResolver>(
        "workspaces/{X-Tenant-Id}", "read");

// Query-based tenant resolution
app.MapGet("/docs", handler)
    .RequireProtectedResource<RouteEndpointBuilder, QueryParameterResolver>(
        "workspaces/{tenant}", "read");

// Custom resolver (e.g., subdomain-based)
app.MapGet("/docs", handler)
    .RequireProtectedResource<RouteEndpointBuilder, SubdomainParameterResolver>(
        "workspaces/{tenant}", "read");
```

## Test plan

- [x] Unit tests for all three built-in resolvers (resolve + not-found cases)
- [x] Tests for `Utils.ResolveResource` with resolver (single/multiple placeholders, unresolvable, no placeholders)
- [x] Tests for integrated resolution pipeline (route default, header via ResolverType)
- [x] Tests for `ProtectedResourceAttribute.ResolverType` property
- [x] Tests for custom resolver with `IServiceProvider` access
- [x] Full test suite passes (23 tests, 0 failures)
- [x] Full solution builds with no errors

Closes #204