### PR TITLE
feat: allow configurable claim type for organization membership parsing

### DIFF
--- a/src/Keycloak.AuthServices.Authorization/KeycloakAuthorizationOptions.cs
+++ b/src/Keycloak.AuthServices.Authorization/KeycloakAuthorizationOptions.cs
@@ -27,6 +27,11 @@ public class KeycloakAuthorizationOptions : KeycloakInstallationOptions
     /// Gets or sets the claim type used for roles.
     /// </summary>
     public string RoleClaimType { get; set; } = KeycloakConstants.RoleClaimType;
+
+    /// <summary>
+    /// Gets or sets the claim type used for organization membership.
+    /// </summary>
+    public string OrganizationClaimType { get; set; } = KeycloakConstants.OrganizationClaimType;
 }
 
 /// <summary>
@@ -53,5 +58,5 @@ public enum RolesClaimTransformationSource
     /// <summary>
     /// Specifies that transformation should be applied to all sources.
     /// </summary>
-    All = Realm | ResourceAccess
+    All = Realm | ResourceAccess,
 }

--- a/src/Keycloak.AuthServices.Authorization/PoliciesBuilderExtensions.cs
+++ b/src/Keycloak.AuthServices.Authorization/PoliciesBuilderExtensions.cs
@@ -159,10 +159,6 @@ public static class PoliciesBuilderExtensions
     private static AuthorizationPolicyBuilder RequireOrganizationMembership(
         this AuthorizationPolicyBuilder builder,
         OrganizationRequirement requirement
-    ) =>
-        builder
-            .RequireAuthenticatedUser()
-            .RequireClaim(KeycloakConstants.OrganizationClaimType)
-            .AddRequirements(requirement);
+    ) => builder.RequireAuthenticatedUser().AddRequirements(requirement);
     #endregion RequireOrganizationMembership
 }

--- a/src/Keycloak.AuthServices.Authorization/Requirements/OrganizationRequirement.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/OrganizationRequirement.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 /// <summary>
 /// Authorization requirement that validates the user's membership in a Keycloak organization.
@@ -59,6 +60,7 @@ public class OrganizationRequirement : IAuthorizationRequirement, IAuthorization
 public class OrganizationRequirementHandler : AuthorizationHandler<OrganizationRequirement>
 {
     private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly IOptions<KeycloakAuthorizationOptions> options;
     private readonly KeycloakMetrics metrics;
     private readonly ILogger<OrganizationRequirementHandler> logger;
 
@@ -66,15 +68,18 @@ public class OrganizationRequirementHandler : AuthorizationHandler<OrganizationR
     /// Initializes a new instance of the <see cref="OrganizationRequirementHandler"/> class.
     /// </summary>
     /// <param name="httpContextAccessor">The HTTP context accessor.</param>
+    /// <param name="options">The Keycloak authorization options.</param>
     /// <param name="metrics">The Keycloak metrics tracker.</param>
     /// <param name="logger">The logger.</param>
     public OrganizationRequirementHandler(
         IHttpContextAccessor httpContextAccessor,
+        IOptions<KeycloakAuthorizationOptions> options,
         KeycloakMetrics metrics,
         ILogger<OrganizationRequirementHandler> logger
     )
     {
         this.httpContextAccessor = httpContextAccessor;
+        this.options = options;
         this.metrics = metrics;
         this.logger = logger;
     }
@@ -101,7 +106,8 @@ public class OrganizationRequirementHandler : AuthorizationHandler<OrganizationR
             return Task.CompletedTask;
         }
 
-        var organizations = context.User.GetOrganizations();
+        var organizationClaimType = this.options.Value.OrganizationClaimType;
+        var organizations = context.User.GetOrganizations(organizationClaimType);
 
         bool success;
 

--- a/src/Keycloak.AuthServices.Common/Claims/KeycloakOrganizationClaimsExtensions.cs
+++ b/src/Keycloak.AuthServices.Common/Claims/KeycloakOrganizationClaimsExtensions.cs
@@ -13,13 +13,15 @@ public static class KeycloakOrganizationClaimsExtensions
     /// Gets the list of organizations the user is a member of.
     /// </summary>
     /// <param name="principal">The claims principal.</param>
+    /// <param name="claimType">Optional claim type override. Defaults to <see cref="KeycloakConstants.OrganizationClaimType"/>.</param>
     /// <returns>A list of organization memberships. Empty if no organization claim is present.</returns>
     public static IReadOnlyList<OrganizationMembership> GetOrganizations(
-        this ClaimsPrincipal principal
+        this ClaimsPrincipal principal,
+        string? claimType = null
     )
     {
         ArgumentNullException.ThrowIfNull(principal);
-        return principal.Claims.GetOrganizations();
+        return GetOrganizations(principal.Claims, claimType);
     }
 
     /// <summary>
@@ -27,14 +29,18 @@ public static class KeycloakOrganizationClaimsExtensions
     /// </summary>
     /// <param name="principal">The claims principal.</param>
     /// <param name="organizationAlias">The organization alias.</param>
+    /// <param name="claimType">Optional claim type override. Defaults to <see cref="KeycloakConstants.OrganizationClaimType"/>.</param>
     /// <returns><c>true</c> if the user is a member of the organization; otherwise, <c>false</c>.</returns>
-    public static bool IsMemberOf(this ClaimsPrincipal principal, string organizationAlias)
+    public static bool IsMemberOf(
+        this ClaimsPrincipal principal,
+        string organizationAlias,
+        string? claimType = null
+    )
     {
         ArgumentNullException.ThrowIfNull(principal);
         ArgumentNullException.ThrowIfNull(organizationAlias);
 
-        return principal
-            .Claims.GetOrganizations()
+        return GetOrganizations(principal.Claims, claimType)
             .Any(o => o.Alias.Equals(organizationAlias, StringComparison.OrdinalIgnoreCase));
     }
 
@@ -43,14 +49,18 @@ public static class KeycloakOrganizationClaimsExtensions
     /// </summary>
     /// <param name="principal">The claims principal.</param>
     /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="claimType">Optional claim type override. Defaults to <see cref="KeycloakConstants.OrganizationClaimType"/>.</param>
     /// <returns><c>true</c> if the user is a member of the organization; otherwise, <c>false</c>.</returns>
-    public static bool IsMemberOfById(this ClaimsPrincipal principal, string organizationId)
+    public static bool IsMemberOfById(
+        this ClaimsPrincipal principal,
+        string organizationId,
+        string? claimType = null
+    )
     {
         ArgumentNullException.ThrowIfNull(principal);
         ArgumentNullException.ThrowIfNull(organizationId);
 
-        return principal
-            .Claims.GetOrganizations()
+        return GetOrganizations(principal.Claims, claimType)
             .Any(o =>
                 o.Id != null && o.Id.Equals(organizationId, StringComparison.OrdinalIgnoreCase)
             );
@@ -77,13 +87,16 @@ public static class KeycloakOrganizationClaimsExtensions
     /// </list>
     /// </remarks>
     /// <param name="claims">The claims collection.</param>
+    /// <param name="claimType">Optional claim type override. Defaults to <see cref="KeycloakConstants.OrganizationClaimType"/>.</param>
     /// <returns>A list of organization memberships. Empty if no organization claim is present.</returns>
     public static IReadOnlyList<OrganizationMembership> GetOrganizations(
-        this IEnumerable<Claim> claims
+        this IEnumerable<Claim> claims,
+        string? claimType = null
     )
     {
+        var effectiveClaimType = claimType ?? OrganizationClaimType;
         var orgClaims = claims
-            .Where(c => c.Type.Equals(OrganizationClaimType, StringComparison.OrdinalIgnoreCase))
+            .Where(c => c.Type.Equals(effectiveClaimType, StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         if (orgClaims.Count == 0)

--- a/tests/Keycloak.AuthServices.Authorization.Tests/Organizations/OrganizationClaimsExtensionsTests.cs
+++ b/tests/Keycloak.AuthServices.Authorization.Tests/Organizations/OrganizationClaimsExtensionsTests.cs
@@ -298,19 +298,76 @@ public class OrganizationClaimsExtensionsTests
         principal.IsMemberOf("acme-corp").Should().BeTrue();
     }
 
-    private static ClaimsPrincipal CreatePrincipal(string organizationClaimValue) =>
+    [Fact]
+    public void GetOrganizations_CustomClaimType_ParsesCorrectly()
+    {
+        var principal = CreatePrincipal(
+            /*lang=json,strict*/
+            """
+            {
+                "acme-corp": { "id": "uuid-1" }
+            }
+            """,
+            claimType: "tenant"
+        );
+
+        var orgs = principal.GetOrganizations("tenant");
+
+        orgs.Should().HaveCount(1);
+        orgs[0].Alias.Should().Be("acme-corp");
+        orgs[0].Id.Should().Be("uuid-1");
+    }
+
+    [Fact]
+    public void GetOrganizations_CustomClaimType_DefaultDoesNotMatch()
+    {
+        var principal = CreatePrincipal(
+            /*lang=json,strict*/
+            """
+            {
+                "acme-corp": {}
+            }
+            """,
+            claimType: "tenant"
+        );
+
+        var orgs = principal.GetOrganizations();
+
+        orgs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IsMemberOf_CustomClaimType_ReturnsTrue()
+    {
+        var principal = CreatePrincipalWithStringClaims(["acme-corp"], claimType: "org");
+
+        principal.IsMemberOf("acme-corp", "org").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsMemberOf_CustomClaimType_DefaultDoesNotMatch()
+    {
+        var principal = CreatePrincipalWithStringClaims(["acme-corp"], claimType: "org");
+
+        principal.IsMemberOf("acme-corp").Should().BeFalse();
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(
+        string organizationClaimValue,
+        string claimType = "organization"
+    ) =>
         new(
             new ClaimsIdentity(
-                [new Claim("organization", organizationClaimValue, JsonValueType, Issuer, Issuer)],
+                [new Claim(claimType, organizationClaimValue, JsonValueType, Issuer, Issuer)],
                 "Bearer"
             )
         );
 
     private static ClaimsPrincipal CreatePrincipalWithStringClaims(params string[] orgAliases) =>
-        new(
-            new ClaimsIdentity(
-                orgAliases.Select(alias => new Claim("organization", alias)),
-                "Bearer"
-            )
-        );
+        CreatePrincipalWithStringClaims(orgAliases, claimType: "organization");
+
+    private static ClaimsPrincipal CreatePrincipalWithStringClaims(
+        string[] orgAliases,
+        string claimType = "organization"
+    ) => new(new ClaimsIdentity(orgAliases.Select(alias => new Claim(claimType, alias)), "Bearer"));
 }

--- a/tests/Keycloak.AuthServices.Authorization.Tests/Organizations/OrganizationRequirementHandlerTests.cs
+++ b/tests/Keycloak.AuthServices.Authorization.Tests/Organizations/OrganizationRequirementHandlerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 public class OrganizationRequirementHandlerTests
 {
@@ -161,18 +162,64 @@ public class OrganizationRequirementHandlerTests
         context.HasSucceeded.Should().BeFalse();
     }
 
-    private static OrganizationRequirementHandler CreateHandler(HttpContext? httpContext = null)
+    [Fact]
+    public async Task CustomClaimType_UserHasOrgs_Succeeds()
     {
-        var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
-        var metrics = new KeycloakMetrics(new TestMeterFactory());
-        var logger = NullLogger<OrganizationRequirementHandler>.Instance;
-        return new OrganizationRequirementHandler(httpContextAccessor, metrics, logger);
+        var requirement = new OrganizationRequirement();
+        var principal = CreatePrincipal(
+            /*lang=json,strict*/
+            """{"acme-corp": {}}""",
+            claimType: "tenant"
+        );
+        var handler = CreateHandler(
+            authorizationOptions: new KeycloakAuthorizationOptions
+            {
+                OrganizationClaimType = "tenant",
+            }
+        );
+
+        var context = new AuthorizationHandlerContext([requirement], principal, null);
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
     }
 
-    private static ClaimsPrincipal CreatePrincipal(string organizationClaimValue) =>
+    [Fact]
+    public async Task CustomClaimType_DefaultClaimType_Fails()
+    {
+        var requirement = new OrganizationRequirement();
+        var principal = CreatePrincipal(
+            /*lang=json,strict*/
+            """{"acme-corp": {}}""",
+            claimType: "tenant"
+        );
+        var handler = CreateHandler();
+
+        var context = new AuthorizationHandlerContext([requirement], principal, null);
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeFalse();
+    }
+
+    private static OrganizationRequirementHandler CreateHandler(
+        HttpContext? httpContext = null,
+        KeycloakAuthorizationOptions? authorizationOptions = null
+    )
+    {
+        var httpContextAccessor = new HttpContextAccessor { HttpContext = httpContext };
+        var options = Options.Create(authorizationOptions ?? new KeycloakAuthorizationOptions());
+        var metrics = new KeycloakMetrics(new TestMeterFactory());
+        var logger = NullLogger<OrganizationRequirementHandler>.Instance;
+        return new OrganizationRequirementHandler(httpContextAccessor, options, metrics, logger);
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(
+        string organizationClaimValue,
+        string claimType = "organization"
+    ) =>
         new(
             new ClaimsIdentity(
-                [new Claim("organization", organizationClaimValue, JsonValueType, Issuer, Issuer)],
+                [new Claim(claimType, organizationClaimValue, JsonValueType, Issuer, Issuer)],
                 "Bearer"
             )
         );


### PR DESCRIPTION
## Summary

Closes #206

- Add `OrganizationClaimType` property to `KeycloakAuthorizationOptions` (defaults to `"organization"`)
- Add optional `claimType` parameter to `GetOrganizations()`, `IsMemberOf()`, and `IsMemberOfById()` extension methods
- Wire configured claim type through `OrganizationRequirementHandler` via `IOptions<KeycloakAuthorizationOptions>`
- Remove hardcoded `RequireClaim` from policy builder to support custom claim types

## Usage

```csharp
// Options-based (applies to authorization handler)
services.AddKeycloakAuthorization(options =>
{
    options.OrganizationClaimType = "tenant";
});

// Per-call override (for extension methods)
principal.GetOrganizations("org");
principal.IsMemberOf("acme-corp", "org");
```

## Test plan

- [x] Existing 50 organization tests pass unchanged
- [x] New tests verify custom claim type works in both extensions and handler
- [x] New tests verify default claim type doesn't match custom claims (negative case)
- [x] CI/CD pipeline passes