### PR TITLE
feat: add client_secret_jwt sample

### DIFF
--- a/KeycloakAuthorizationServicesDotNet.slnx
+++ b/KeycloakAuthorizationServicesDotNet.slnx
@@ -17,6 +17,7 @@
     <Project Path="samples/AuthGettingStarted/AuthGettingStarted.csproj" />
     <Project Path="samples/AuthorizationAndCleanArchitecture/AuthorizationAndCleanArchitecture.csproj" />
     <Project Path="samples/AuthorizationGettingStarted/AuthorizationGettingStarted.csproj" />
+    <Project Path="samples/ClientSecretJwt/ClientSecretJwt.csproj" />
     <Project Path="samples/GettingStarted/GettingStarted.csproj" />
     <Project Path="samples/ResourceAuthorization/ResourceAuthorization.csproj" />
     <Project Path="samples/WebApp/WebApp.csproj" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -147,6 +147,7 @@ export default withMermaid({
                         { text: 'Web API + Blazor', link: '/examples/web-api-blazor' },
                         { text: 'Organization Authorization', link: '/examples/organization-authorization' },
                         { text: 'Token Introspection', link: '/examples/token-introspection' },
+                        { text: 'Client Secret JWT', link: '/examples/client-secret-jwt' },
                     ]
                 }
             ]

--- a/docs/examples/client-secret-jwt.md
+++ b/docs/examples/client-secret-jwt.md
@@ -1,0 +1,11 @@
+# Client Secret JWT (client_secret_jwt)
+
+This sample demonstrates how to use Keycloak's **"Signed JWT with Client Secret"** client authentication method (`client_secret_jwt`).
+
+Instead of sending the raw client secret over the wire, the app builds a short-lived HS256-signed JWT assertion and sends that to Keycloak's token endpoint. Keycloak verifies the signature using the same shared secret — the secret itself never leaves the application.
+
+This satisfies compliance policies that prohibit transmitting client secrets over the network.
+
+<<< @/../samples/ClientSecretJwt/ClientSecretJwtAssertionService.cs
+
+See sample source code: [keycloak-authorization-services-dotnet/tree/main/samples/ClientSecretJwt](https://github.com/NikiforovAll/keycloak-authorization-services-dotnet/tree/main/samples/ClientSecretJwt)

--- a/samples/ClientSecretJwt/ClientSecretJwt.csproj
+++ b/samples/ClientSecretJwt/ClientSecretJwt.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Keycloak.AuthServices.Common\Keycloak.AuthServices.Common.csproj" />
+    <ProjectReference Include="..\..\src\Keycloak.AuthServices.Sdk\Keycloak.AuthServices.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Duende.AccessTokenManagement" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ClientSecretJwt/ClientSecretJwtAssertionService.cs
+++ b/samples/ClientSecretJwt/ClientSecretJwtAssertionService.cs
@@ -1,0 +1,61 @@
+namespace ClientSecretJwt;
+
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Duende.AccessTokenManagement;
+using Duende.IdentityModel;
+using Duende.IdentityModel.Client;
+using Keycloak.AuthServices.Sdk;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
+/// <summary>
+/// Implements Duende's <see cref="IClientAssertionService"/> for the
+/// <c>client_secret_jwt</c> authentication method (RFC 7523 / Keycloak "Signed JWT with Client Secret").
+///
+/// Instead of sending the shared secret over the wire, this service builds a short-lived
+/// HS256-signed JWT (<c>client_assertion</c>). Keycloak verifies the signature using the
+/// same shared secret it already holds — the secret itself never leaves the application.
+/// </summary>
+public sealed class ClientSecretJwtAssertionService(IOptions<KeycloakAdminClientOptions> options)
+    : IClientAssertionService
+{
+    private readonly KeycloakAdminClientOptions _options = options.Value;
+
+    public Task<ClientAssertion?> GetClientAssertionAsync(
+        ClientCredentialsClientName? clientName = null,
+        TokenRequestParameters? parameters = null,
+        CancellationToken ct = default
+    )
+    {
+        var clientId = _options.Resource;
+        var tokenEndpoint = _options.KeycloakTokenEndpoint;
+        var secret = _options.Credentials.Secret;
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var now = DateTime.UtcNow;
+        var token = new JwtSecurityToken(
+            issuer: clientId,
+            audience: tokenEndpoint,
+            claims:
+            [
+                new Claim(JwtRegisteredClaimNames.Sub, clientId),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            ],
+            notBefore: now,
+            expires: now.AddMinutes(1),
+            signingCredentials: credentials
+        );
+
+        return Task.FromResult<ClientAssertion?>(
+            new ClientAssertion
+            {
+                Type = OidcConstants.ClientAssertionTypes.JwtBearer,
+                Value = new JwtSecurityTokenHandler().WriteToken(token),
+            }
+        );
+    }
+}

--- a/samples/ClientSecretJwt/KeycloakConfiguration/Test-realm.json
+++ b/samples/ClientSecretJwt/KeycloakConfiguration/Test-realm.json
@@ -1,0 +1,19 @@
+{
+  "realm": "Test",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "api-client",
+      "name": "API Client (client_secret_jwt)",
+      "enabled": true,
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret-jwt",
+      "secret": "s3cr3t-f0r-signing-jwt-ass3rtion",
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false
+    }
+  ]
+}

--- a/samples/ClientSecretJwt/KeycloakConfiguration/Test-users-0.json
+++ b/samples/ClientSecretJwt/KeycloakConfiguration/Test-users-0.json
@@ -1,0 +1,20 @@
+{
+  "realm": "Test",
+  "users": [
+    {
+      "username": "service-account-api-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "api-client",
+      "clientRoles": {
+        "realm-management": [
+          "view-realm",
+          "view-users",
+          "query-users",
+          "query-realms"
+        ]
+      }
+    }
+  ]
+}

--- a/samples/ClientSecretJwt/Program.cs
+++ b/samples/ClientSecretJwt/Program.cs
@@ -1,0 +1,63 @@
+using ClientSecretJwt;
+using Duende.AccessTokenManagement;
+using Keycloak.AuthServices.Common;
+using Keycloak.AuthServices.Sdk;
+using Keycloak.AuthServices.Sdk.Admin;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var configuration = builder.Configuration;
+var services = builder.Services;
+
+// Register the JWT assertion service.
+// When Duende requests a token, this service builds a short-lived HS256-signed JWT
+// (client_assertion) using the shared secret. Only the signed JWT travels over the wire —
+// the raw secret never does.
+services.AddSingleton<IClientAssertionService, ClientSecretJwtAssertionService>();
+
+services.AddDistributedMemoryCache();
+
+// Configure Duende client credentials token management.
+// Note: ClientSecret is intentionally omitted — IClientAssertionService handles auth.
+services
+    .AddClientCredentialsTokenManagement()
+    .AddClient(
+        "keycloak",
+        client =>
+        {
+            var keycloakOptions = configuration.GetKeycloakOptions<KeycloakAdminClientOptions>()!;
+            client.ClientId = ClientId.Parse(keycloakOptions.Resource);
+            client.TokenEndpoint = new Uri(keycloakOptions.KeycloakTokenEndpoint);
+        }
+    );
+
+// Register the Keycloak Admin HTTP client and attach the Duende token handler.
+services
+    .AddKeycloakAdminHttpClient(configuration)
+    .AddClientCredentialsTokenHandler(ClientCredentialsClientName.Parse("keycloak"));
+
+var app = builder.Build();
+
+// Returns the Test realm info from Keycloak Admin API.
+// Requires: view-realm role on the service account.
+app.MapGet(
+    "/realm",
+    async (IKeycloakRealmClient client) =>
+    {
+        var realm = await client.GetRealmAsync("Test");
+        return Results.Ok(realm);
+    }
+);
+
+// Lists users in the Test realm.
+// Requires: view-users role on the service account.
+app.MapGet(
+    "/users",
+    async (IKeycloakUserClient client) =>
+    {
+        var users = await client.GetUsersAsync("Test");
+        return Results.Ok(users);
+    }
+);
+
+await app.RunAsync();

--- a/samples/ClientSecretJwt/Properties/launchSettings.json
+++ b/samples/ClientSecretJwt/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5099",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/ClientSecretJwt/README.md
+++ b/samples/ClientSecretJwt/README.md
@@ -1,0 +1,143 @@
+# `client_secret_jwt` Authentication Sample
+
+Demonstrates how to use Keycloak's **"Signed JWT with Client Secret"** (`client_secret_jwt`) authentication method with `Keycloak.AuthServices.Sdk` and `Duende.AccessTokenManagement`.
+
+> **Why?** Some compliance policies prohibit sending the shared secret over the wire, even when protected by TLS. With `client_secret_jwt`, the secret is used locally as an HMAC signing key — only a short-lived, signed JWT travels to Keycloak.
+
+## How `client_secret_jwt` Works
+
+```
+Your App                   Keycloak Token Endpoint
+   │                               │
+   │  1. Build JWT assertion        │
+   │     iss = api-client           │
+   │     sub = api-client           │
+   │     aud = <token-endpoint>     │
+   │     exp = now + 60s            │
+   │     Sign with HS256(secret)    │
+   │                               │
+   │  2. POST /token               │
+   │     client_assertion=<jwt>    │
+   │     client_assertion_type=    │
+   │       urn:...:jwt-bearer      │
+   │──────────────────────────────►│
+   │                               │  3. Verify JWT signature
+   │                               │     using the stored shared secret
+   │◄──────────────────────────────│
+   │  4. { access_token: "..." }   │
+```
+
+The shared secret **never leaves** the application.
+
+## Prerequisites
+
+- Docker / Podman
+- .NET 10 SDK
+
+## Quick Start
+
+```bash
+# 1. Start Keycloak with the pre-configured Test realm
+docker compose up -d
+
+# 2. Run the sample (waits ~10s for Keycloak to be ready)
+dotnet run
+```
+
+Then use `assets/run.http` (VS Code REST Client) to test the endpoints:
+
+```bash
+# Or with curl:
+curl http://localhost:5099/realm
+curl http://localhost:5099/users
+```
+
+## What Gets Created
+
+Keycloak is seeded automatically via `--import-realm`:
+
+| Resource | Details |
+|----------|---------|
+| Realm | `Test` |
+| Client | `api-client` — confidential, `clientAuthenticatorType: client-secret-jwt`, service accounts enabled |
+| Secret | `s3cr3t-f0r-signing-jwt-ass3rtion` (shared HMAC key, not sent over wire) |
+| Service Account Roles | `view-realm`, `view-users`, `query-users`, `query-realms` from `realm-management` |
+
+## Keycloak UI Setup (manual reference)
+
+If configuring a real Keycloak instance manually:
+
+1. Open **Clients** → your client → **Credentials** tab
+2. Set **Client Authenticator** → **"Signed JWT with Client Secret"**
+3. Note the **Secret** value — this becomes your HMAC signing key
+
+![Keycloak client_secret_jwt UI](https://github.com/user-attachments/assets/1b0d3953-3b62-4604-b6d5-92afd9358c06)
+
+## How It Works
+
+### 1. Register the assertion service
+
+```csharp
+// ClientSecretJwtAssertionService.cs
+// Implements Duende's IClientAssertionService to produce the JWT assertion.
+// The raw secret (credentials.secret) is used only as the HS256 signing key.
+services.AddSingleton<IClientAssertionService, ClientSecretJwtAssertionService>();
+```
+
+### 2. Configure token management — no ClientSecret
+
+```csharp
+services
+    .AddClientCredentialsTokenManagement()
+    .AddClient("keycloak", client =>
+    {
+        client.ClientId = keycloakOptions.Resource;
+        client.TokenEndpoint = new Uri(keycloakOptions.KeycloakTokenEndpoint);
+        // No ClientSecret — IClientAssertionService handles auth
+    });
+```
+
+### 3. Attach the token handler to the HttpClient
+
+```csharp
+services
+    .AddKeycloakAdminHttpClient(configuration)
+    .AddClientCredentialsTokenHandler("keycloak");
+```
+
+### 4. The assertion builder (`ClientSecretJwtAssertionService`)
+
+```csharp
+var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+var token = new JwtSecurityToken(
+    issuer: clientId,
+    audience: tokenEndpoint,
+    claims: [new Claim("sub", clientId), new Claim("jti", Guid.NewGuid().ToString())],
+    expires: DateTime.UtcNow.AddMinutes(1),
+    signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256)
+);
+// Sent as: client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer
+//          client_assertion=<signed JWT>
+```
+
+## Endpoints
+
+| Endpoint | Description | Required role |
+|----------|-------------|---------------|
+| `GET /realm` | Returns `Test` realm info | `view-realm` |
+| `GET /users` | Lists users in `Test` realm | `view-users` |
+
+## Comparison with Other Auth Methods
+
+| Method | Secret on wire? | Library support |
+|--------|----------------|-----------------|
+| `client_secret_post` | ✅ Yes (POST body, TLS-protected) | ✅ Default |
+| `client_secret_basic` | ✅ Yes (Authorization header, TLS-protected) | ✅ Via Duende |
+| `client_secret_jwt` | ❌ No — only HMAC-signed JWT sent | ✅ **This sample** |
+| `private_key_jwt` | ❌ No — only asymmetric-signed JWT sent | 🔲 Future |
+
+## Cleanup
+
+```bash
+docker compose down -v
+```

--- a/samples/ClientSecretJwt/appsettings.Development.json
+++ b/samples/ClientSecretJwt/appsettings.Development.json
@@ -1,0 +1,11 @@
+{
+  "Keycloak": {
+    "realm": "Test",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "api-client",
+    "credentials": {
+      "secret": "s3cr3t-f0r-signing-jwt-ass3rtion"
+    }
+  }
+}

--- a/samples/ClientSecretJwt/appsettings.json
+++ b/samples/ClientSecretJwt/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/ClientSecretJwt/assets/run.http
+++ b/samples/ClientSecretJwt/assets/run.http
@@ -1,0 +1,16 @@
+@host = http://localhost:5099
+
+## ─── Realm Info ───
+
+### Get Test realm details (expects: 200 with realm JSON)
+GET {{host}}/realm
+
+## ─── Users ───
+
+### List users in Test realm (expects: 200 with users array)
+GET {{host}}/users
+
+## ─── Keycloak Token Endpoint (direct) ───
+
+### Verify token endpoint is alive
+GET http://localhost:8080/realms/Test/.well-known/openid-configuration

--- a/samples/ClientSecretJwt/docker-compose.yml
+++ b/samples/ClientSecretJwt/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.5.6
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    command:
+      [
+        'start-dev',
+        '--import-realm',
+      ]
+    volumes:
+      - ./KeycloakConfiguration/:/opt/keycloak/data/import/
+    ports:
+      - 8080:8080

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Duende.AccessTokenManagement" Version="4.2.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     <PackageVersion Include="Keycloak.AuthServices.Authentication" Version="1.7.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />


### PR DESCRIPTION
## Summary

Adds a self-contained sample demonstrating Keycloak's **"Signed JWT with Client Secret"** (`client_secret_jwt`) client authentication method, requested in #174.

Instead of sending the raw client secret over the wire, the app builds a short-lived HS256-signed JWT assertion using Duende's `IClientAssertionService` extension point. The secret never leaves the application — only the signed JWT travels to Keycloak's token endpoint.

## What's included

- **`ClientSecretJwtAssertionService`** — implements `IClientAssertionService` to build the HS256-signed JWT assertion
- **Self-contained Keycloak setup** — realm seeded via `--import-realm` with `api-client` configured as `client_secret_jwt`; just run `podman compose up`
- **`/realm` and `/users` endpoints** — call the Admin API using the token obtained via `client_secret_jwt` flow
- **README** with diagrams, quick start, and comparison table
- **Docs page** added to the Examples section in VitePress

## Quick start

```bash
cd samples/ClientSecretJwt
podman compose up -d   # or docker compose up -d
dotnet run
curl http://localhost:5099/realm
```

Closes #174