### PR TITLE
feat(authorization): add Audience override for per-resource UMA ticket exchange

### DIFF
--- a/src/Keycloak.AuthServices.Authorization/AuthorizationServer/AuthorizationServerClient.cs
+++ b/src/Keycloak.AuthServices.Authorization/AuthorizationServer/AuthorizationServerClient.cs
@@ -8,34 +8,29 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 /// <inheritdoc />
-public class AuthorizationServerClient : IAuthorizationServerClient
+/// <summary>
+/// </summary>
+/// <param name="httpClient"></param>
+/// <param name="clientOptions"></param>
+/// <param name="logger"></param>
+/// <exception cref="ArgumentNullException"></exception>
+public class AuthorizationServerClient(
+    HttpClient httpClient,
+    IOptions<KeycloakAuthorizationServerOptions> clientOptions,
+    ILogger<AuthorizationServerClient> logger
+) : IAuthorizationServerClient
 {
-    private readonly HttpClient httpClient;
-    private readonly IOptions<KeycloakAuthorizationServerOptions> options;
-    private readonly ILogger<AuthorizationServerClient> logger;
-
-    /// <summary>
-    /// </summary>
-    /// <param name="httpClient"></param>
-    /// <param name="clientOptions"></param>
-    /// <param name="logger"></param>
-    /// <exception cref="ArgumentNullException"></exception>
-    public AuthorizationServerClient(
-        HttpClient httpClient,
-        IOptions<KeycloakAuthorizationServerOptions> clientOptions,
-        ILogger<AuthorizationServerClient> logger
-    )
-    {
-        this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        this.options = clientOptions;
-        this.logger = logger;
-    }
+    private readonly HttpClient httpClient =
+        httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+    private readonly IOptions<KeycloakAuthorizationServerOptions> options = clientOptions;
+    private readonly ILogger<AuthorizationServerClient> logger = logger;
 
     /// <inheritdoc />
     public async Task<bool> VerifyAccessToResource(
         string resource,
         string scope,
         ScopesValidationMode? scopesValidationMode = default,
+        string? audience = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -48,6 +43,7 @@ public class AuthorizationServerClient : IAuthorizationServerClient
             resource,
             scope,
             accessToken: null,
+            audience,
             scopesValidationMode,
             cancellationToken
         );
@@ -72,6 +68,7 @@ public class AuthorizationServerClient : IAuthorizationServerClient
             resource,
             scope,
             accessToken,
+            audience: null,
             scopesValidationMode,
             cancellationToken
         );
@@ -81,13 +78,16 @@ public class AuthorizationServerClient : IAuthorizationServerClient
         string resource,
         string scope,
         string? accessToken,
+        string? audience,
         ScopesValidationMode? scopesValidationMode,
         CancellationToken cancellationToken
     )
     {
         try
         {
-            using var content = new FormUrlEncodedContent(this.PrepareRequest(resource, scope));
+            using var content = new FormUrlEncodedContent(
+                this.PrepareRequest(resource, scope, audience)
+            );
             using var request = new HttpRequestMessage(
                 HttpMethod.Post,
                 KeycloakConstants.TokenEndpointPath
@@ -121,17 +121,21 @@ public class AuthorizationServerClient : IAuthorizationServerClient
         }
     }
 
-    private Dictionary<string, string> PrepareRequest(string resource, string scope)
+    private Dictionary<string, string> PrepareRequest(
+        string resource,
+        string scope,
+        string? audience = null
+    )
     {
         var permission = string.IsNullOrWhiteSpace(scope) ? resource : $"{resource}#{scope}";
-        var audience = this.options.Value.Resource ?? string.Empty;
+        var resolvedAudience = audience ?? this.options.Value.Resource ?? string.Empty;
         var responseMode = scope.Contains(',') ? "permissions" : "decision";
 
         return new Dictionary<string, string>
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket" },
             { "response_mode", responseMode },
-            { "audience", audience },
+            { "audience", resolvedAudience },
             { "permission", permission },
         };
     }

--- a/src/Keycloak.AuthServices.Authorization/AuthorizationServer/IAuthorizationServerClient.cs
+++ b/src/Keycloak.AuthServices.Authorization/AuthorizationServer/IAuthorizationServerClient.cs
@@ -12,12 +12,12 @@ public interface IAuthorizationServerClient
     /// <param name="scope"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<bool> VerifyAccessToResource(
+    public Task<bool> VerifyAccessToResource(
         string resource,
         string scope,
         CancellationToken cancellationToken = default
     ) =>
-        this.VerifyAccessToResource(resource, scope, ScopesValidationMode.AllOf, cancellationToken);
+        this.VerifyAccessToResource(resource, scope, ScopesValidationMode.AllOf, audience: null, cancellationToken);
 
     /// <summary>
     /// Verifies access to the protected resource. Sends decision request to token endpoint {resource}#{scope}
@@ -25,12 +25,17 @@ public interface IAuthorizationServerClient
     /// <param name="resource"></param>
     /// <param name="scope"></param>
     /// <param name="scopesValidationMode"></param>
+    /// <param name="audience">
+    /// The Keycloak client ID of the target resource server to use as the UMA <c>audience</c> parameter.
+    /// When <c>null</c>, the global <c>KeycloakAuthorizationServerOptions.Resource</c> value is used.
+    /// </param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<bool> VerifyAccessToResource(
+    public Task<bool> VerifyAccessToResource(
         string resource,
         string scope,
         ScopesValidationMode? scopesValidationMode = default,
+        string? audience = null,
         CancellationToken cancellationToken = default
     );
 
@@ -44,7 +49,7 @@ public interface IAuthorizationServerClient
     /// <param name="accessToken">The access token to use for the authorization request.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<bool> VerifyAccessToResource(
+    public Task<bool> VerifyAccessToResource(
         string resource,
         string scope,
         string accessToken,
@@ -69,7 +74,7 @@ public interface IAuthorizationServerClient
     /// <param name="scopesValidationMode"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<bool> VerifyAccessToResource(
+    public Task<bool> VerifyAccessToResource(
         string resource,
         string scope,
         string accessToken,

--- a/src/Keycloak.AuthServices.Authorization/IProtectedResourceData.cs
+++ b/src/Keycloak.AuthServices.Authorization/IProtectedResourceData.cs
@@ -16,6 +16,12 @@ public interface IProtectedResourceData
     public string[]? Scopes { get; }
 
     /// <summary>
+    /// Gets the Keycloak client ID of the resource server to use as the UMA <c>audience</c> parameter.
+    /// When <c>null</c>, the global <c>KeycloakAuthorizationServerOptions.Resource</c> value is used.
+    /// </summary>
+    public string? Audience => null;
+
+    /// <summary>
     /// Gets the type of <see cref="IParameterResolver"/> used to resolve resource template parameters.
     /// When <c>null</c>, the default <c>RouteParameterResolver</c> is used.
     /// </summary>

--- a/src/Keycloak.AuthServices.Authorization/ProtectedResourceAttribute.cs
+++ b/src/Keycloak.AuthServices.Authorization/ProtectedResourceAttribute.cs
@@ -27,6 +27,9 @@ public sealed class ProtectedResourceAttribute(string resource, string[] scopes)
     /// <inheritdoc/>
     public string[]? Scopes { get; } = scopes;
 
+    /// <inheritdoc/>
+    public string? Audience { get; set; }
+
     /// <summary>
     /// Gets or sets the type of <see cref="IParameterResolver"/> used to resolve resource template parameters.
     /// When <c>null</c>, the default <c>RouteParameterResolver</c> is used.

--- a/src/Keycloak.AuthServices.Authorization/Requirements/DecisionRequirement.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/DecisionRequirement.cs
@@ -27,6 +27,12 @@ public class DecisionRequirement : IAuthorizationRequirement, IProtectedResource
     public ScopesValidationMode? ScopesValidationMode { get; set; }
 
     /// <summary>
+    /// Gets or sets the Keycloak client ID of the resource server to use as the UMA <c>audience</c> parameter.
+    /// When <c>null</c>, the global <c>KeycloakAuthorizationServerOptions.Resource</c> value is used.
+    /// </summary>
+    public string? Audience { get; set; }
+
+    /// <summary>
     /// Constructs requirement
     /// </summary>
     /// <param name="resource"></param>
@@ -34,7 +40,7 @@ public class DecisionRequirement : IAuthorizationRequirement, IProtectedResource
     public DecisionRequirement(string resource, string scope)
     {
         this.Resource = resource;
-        this.Scopes = new[] { scope };
+        this.Scopes = [scope];
     }
 
     /// <summary>
@@ -127,6 +133,7 @@ public class DecisionRequirementHandler(
             scopes,
             nameof(DecisionRequirement),
             requirement.ScopesValidationMode,
+            requirement.Audience,
             CancellationToken.None
         );
 

--- a/src/Keycloak.AuthServices.Authorization/Requirements/ParameterizedProtectedResourceRequirement.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/ParameterizedProtectedResourceRequirement.cs
@@ -96,6 +96,7 @@ public class ParameterizedProtectedResourceRequirementHandler(
                 resource,
                 scopes,
                 nameof(ParameterizedProtectedResourceRequirement),
+                audience: entry.Audience,
                 cancellationToken: CancellationToken.None
             );
             verificationPlan.Complete(entry.Resource, success);

--- a/src/Keycloak.AuthServices.Authorization/Requirements/ProtectedResourceVerifier.cs
+++ b/src/Keycloak.AuthServices.Authorization/Requirements/ProtectedResourceVerifier.cs
@@ -5,28 +5,22 @@ using Keycloak.AuthServices.Authorization.AuthorizationServer;
 using Microsoft.Extensions.Logging;
 using static Keycloak.AuthServices.Authorization.ActivityConstants;
 
-internal sealed class ProtectedResourceVerifier
+internal sealed class ProtectedResourceVerifier(
+    IAuthorizationServerClient client,
+    KeycloakMetrics metrics,
+    ILogger logger
+)
 {
-    private readonly IAuthorizationServerClient client;
-    private readonly KeycloakMetrics metrics;
-    private readonly ILogger logger;
-
-    public ProtectedResourceVerifier(
-        IAuthorizationServerClient client,
-        KeycloakMetrics metrics,
-        ILogger logger
-    )
-    {
-        this.client = client;
-        this.metrics = metrics;
-        this.logger = logger;
-    }
+    private readonly IAuthorizationServerClient client = client;
+    private readonly KeycloakMetrics metrics = metrics;
+    private readonly ILogger logger = logger;
 
     public async Task<bool> Verify(
         string resource,
         string scopes,
         string requirement,
         ScopesValidationMode? scopesValidationMode = default,
+        string? audience = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -46,6 +40,7 @@ internal sealed class ProtectedResourceVerifier
                 resource,
                 scopes,
                 scopesValidationMode,
+                audience,
                 cancellationToken
             );
         }

--- a/tests/Keycloak.AuthServices.Authorization.Tests/AuthorizationServerClientTests.cs
+++ b/tests/Keycloak.AuthServices.Authorization.Tests/AuthorizationServerClientTests.cs
@@ -148,6 +148,62 @@ public class AuthorizationServerClientTests
         await act.Should().ThrowAsync<ArgumentException>();
     }
 
+    [Fact]
+    public async Task VerifyAccessToResource_WithAudienceOverride_UsesAudienceInsteadOfConfig()
+    {
+        string? capturedBody = null;
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, $"*/{TokenEndpoint}")
+            .With(req =>
+            {
+                capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
+            })
+            .Respond(HttpStatusCode.OK, "application/json", DecisionResponse);
+
+        var client = CreateClient(mockHttp);
+
+        var result = await client.VerifyAccessToResource(
+            "invoice",
+            "read",
+            scopesValidationMode: null,
+            audience: "billing-api"
+        );
+
+        result.Should().BeTrue();
+        capturedBody.Should().Contain("audience=billing-api");
+        capturedBody.Should().NotContain("audience=test-client");
+    }
+
+    [Fact]
+    public async Task VerifyAccessToResource_NullAudience_FallsBackToConfigResource()
+    {
+        string? capturedBody = null;
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp
+            .When(HttpMethod.Post, $"*/{TokenEndpoint}")
+            .With(req =>
+            {
+                capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                return true;
+            })
+            .Respond(HttpStatusCode.OK, "application/json", DecisionResponse);
+
+        var client = CreateClient(mockHttp);
+
+        await client.VerifyAccessToResource(
+            "invoice",
+            "read",
+            scopesValidationMode: null,
+            audience: null
+        );
+
+        capturedBody.Should().Contain("audience=test-client");
+    }
+
     private static AuthorizationServerClient CreateClient(
         MockHttpMessageHandler mockHttp,
         KeycloakAuthorizationServerOptions? options = null


### PR DESCRIPTION
## Summary

Closes #135

Enables a single .NET API to enforce authorization policies from **multiple Keycloak resource server clients** (same realm) by adding an optional `Audience` property that overrides the UMA ticket `audience` parameter on a per-resource/policy basis.

## Problem

Previously, the `audience` parameter in every UMA ticket request was always taken from the global `KeycloakAuthorizationServerOptions.Resource`. There was no way to route individual resource checks to a different Keycloak client within the same realm.

## Solution

Added an optional `Audience` property threaded through the entire authorization call chain:

```
[ProtectedResource(audience: "orders-service")]  // or DecisionRequirement.Audience
  → ProtectedResourceVerifier.Verify(..., audience)
    → IAuthorizationServerClient.VerifyAccessToResource(..., audience)
      → PrepareRequest → audience ?? options.Value.Resource  // fallback preserved
```

When `Audience` is `null`, behaviour is fully backward-compatible — the global config value is used as before.

## Usage

**Attribute-based:**
```csharp
[ProtectedResource("orders", "read", Audience = "orders-service")]
public IActionResult GetOrder() { ... }
```

**Policy-based (`DecisionRequirement`):**
```csharp
services.AddAuthorization(options =>
{
    options.AddPolicy("ReadOrders", policy =>
        policy.AddRequirements(new DecisionRequirement("orders", "read")
        {
            Audience = "orders-service"
        }));
});
```

## Changes

- `IProtectedResourceData` — added `string? Audience => null;` default interface property
- `ProtectedResourceAttribute` — added `public string? Audience { get; set; }`
- `DecisionRequirement` — added `public string? Audience { get; set; }`
- `ProtectedResourceVerifier.Verify` — added `string? audience = null` param (before `CancellationToken`)
- `IAuthorizationServerClient` — added `audience` param to main overload
- `AuthorizationServerClient.PrepareRequest` — uses `audience ?? options.Value.Resource`
- Tests — 2 new unit tests covering audience override and null fallback

## Notes

- Scenario C (different realm) is out of scope — would require named HTTP clients
- No breaking changes for existing call sites (all params are optional with defaults)