### PR TITLE
feat(aspire): external DB support, issuer pinning, version bumps

### DIFF
--- a/docs/devex/aspire.md
+++ b/docs/devex/aspire.md
@@ -103,6 +103,53 @@ Inside docker container run:
 /opt/keycloak/bin/kc.sh export --dir /opt/keycloak/data/import --realm Test
 ```
 
+## Use an external database
+
+By default the Keycloak container uses the embedded H2 database, which is not suitable for anything beyond local exploration. Wire an external database via one of the typed extensions:
+
+```csharp
+var postgres = builder
+    .AddPostgres("postgres")
+    .WithDataVolume()
+    .AddDatabase("keycloak-db", databaseName: "keycloak");
+
+var keycloak = builder
+    .AddKeycloakContainer("keycloak")
+    .WithPostgresDatabase(postgres);
+```
+
+The extension reads the resolved Aspire connection string at deploy time, translates it to JDBC, and sets `KC_DB`, `KC_DB_URL`, `KC_DB_USERNAME`, and `KC_DB_PASSWORD` on the Keycloak container. It also applies `WaitFor(database)`, so Keycloak only starts after the database is ready.
+
+Available overloads — one per Keycloak-supported vendor:
+
+| Extension | `KC_DB` |
+|---|---|
+| `WithPostgresDatabase` | `postgres` |
+| `WithMySqlDatabase` | `mysql` |
+| `WithMariaDbDatabase` | `mariadb` |
+| `WithMsSqlDatabase` | `mssql` |
+| `WithOracleDatabase` | `oracle` |
+
+Each takes any `IResourceBuilder<IResourceWithConnectionString>`, so you can also point Keycloak at a managed database resource (e.g. an Aspire connection-string-only reference for a hosted Postgres).
+
+## Pin the issuer hostname
+
+Keycloak in development mode derives the `iss` claim from whichever URL it is reached on. When API consumers run inside containers (e.g. `host.docker.internal`) but tokens were obtained via `localhost`, you'll see:
+
+```
+WWW-Authenticate: Bearer error="invalid_token", error_description="The issuer 'http://localhost:8080/realms/...' is invalid"
+```
+
+Pin the hostname so every issued token uses the same `iss` regardless of how the container is reached:
+
+```csharp
+var keycloak = builder
+    .AddKeycloakContainer("keycloak")
+    .WithHostname("http://localhost:8080/");
+```
+
+This sets `KC_HOSTNAME` on the container. For non-Aspire scenarios see the [containerized API recipe](/qa/recipes#how-to-connect-a-containerized-api-to-keycloak).
+
 ## Start from Template
 
 You can use [Keycloak.AuthServices.Templates](https://www.nuget.org/packages/Keycloak.AuthServices.Templates) to scaffold the new Aspire Project that has `Keycloak.AuthServices` integration configured.

--- a/docs/qa/recipes.md
+++ b/docs/qa/recipes.md
@@ -109,6 +109,77 @@ app.Run();
 
 :::
 
+## How to connect a containerized API to Keycloak?
+
+When running your .NET API inside a Docker container alongside a Keycloak container, you may see:
+
+```
+WWW-Authenticate: Bearer error="invalid_token", error_description="The issuer 'http://localhost:8080/realms/my-realm' is invalid"
+```
+
+### Root cause
+
+Keycloak embeds its own URL in every token's `iss` (issuer) claim. In dev mode, the issuer is derived from the URL Keycloak was reached on when the token was issued. Your containerized API fetches OIDC metadata from a different base URL (e.g. `host.docker.internal`) than the one used to issue the token (e.g. `localhost`), causing a mismatch.
+
+### Solution 1 — Pin Keycloak's hostname (recommended)
+
+Set `KC_HOSTNAME` so Keycloak always issues tokens with a fixed base URL regardless of how it is accessed:
+
+```bash
+docker run -p 8080:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  -e KC_HOSTNAME=http://localhost:8080/ \
+  quay.io/keycloak/keycloak:26.6.1 start-dev
+```
+
+Configure your API to fetch OIDC metadata via `host.docker.internal` (reachable from inside the container) while validating the fixed issuer:
+
+```json
+{
+  "Keycloak": {
+    "realm": "my-realm",
+    "auth-server-url": "http://host.docker.internal:8080/",
+    "ssl-required": "none",
+    "resource": "my-client"
+  }
+}
+```
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(configuration, options =>
+{
+    options.TokenValidationParameters.ValidIssuer = "http://localhost:8080/realms/my-realm";
+    options.RequireHttpsMetadata = false;
+});
+```
+
+> [!TIP]
+> If you're using Aspire, prefer the [`WithHostname`](/devex/aspire#pin-the-issuer-hostname) extension instead of setting `KC_HOSTNAME` manually.
+
+### Solution 2 — Use `host.docker.internal` everywhere
+
+Obtain tokens using `http://host.docker.internal:8080` (configure your HTTP client or Postman to use this URL) and set `auth-server-url` to the same value. Token issuer and API authority match automatically.
+
+### Solution 3 — Accept multiple valid issuers
+
+For maximum flexibility during local development, accept tokens from multiple issuers:
+
+```csharp
+builder.Services.AddKeycloakWebApiAuthentication(configuration, options =>
+{
+    options.TokenValidationParameters.ValidIssuers = new[]
+    {
+        "http://localhost:8080/realms/my-realm",
+        "http://host.docker.internal:8080/realms/my-realm"
+    };
+    options.RequireHttpsMetadata = false;
+});
+```
+
+> [!TIP]
+> For production, always set `KC_HOSTNAME` to a stable public URL and ensure `auth-server-url` in your API points to a URL reachable from inside the container.
+
 ## How to setup resiliency to HTTP Clients?
 
 Every HTTP Client provided by `Keycloak.AuthServices` expose `IHttpClientBuilder`. It a standard way to extend behavior of `HttpClient`. We can use it to our advantage!

--- a/samples/Directory.Packages.props
+++ b/samples/Directory.Packages.props
@@ -37,6 +37,7 @@
   <ItemGroup Label="Aspire">
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting" Version="13.2.2" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.14.0-beta.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0-beta.2" />

--- a/samples/GettingStartedAndAspire/Api/Api.csproj
+++ b/samples/GettingStartedAndAspire/Api/Api.csproj
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="NSwag.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GettingStartedAndAspire/Api/Program.cs
+++ b/samples/GettingStartedAndAspire/Api/Program.cs
@@ -1,6 +1,8 @@
+using System.Security.Claims;
 using Keycloak.AuthServices.Authentication;
 using Keycloak.AuthServices.Common;
 using Microsoft.OpenApi;
+using NSwag.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
@@ -8,29 +10,49 @@ var configuration = builder.Configuration;
 
 builder.AddServiceDefaults();
 
-var clientName = "workspaces-client";
+const string clientName = "workspaces-client";
+const string schemeName = "oauth2";
 
-services.AddEndpointsApiExplorer();
-services.AddSwaggerGen(c =>
+var keycloakOptions = configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
+var realmUrl = keycloakOptions.KeycloakUrlRealm.TrimEnd('/') + "/";
+
+services.AddOpenApi(options =>
 {
-    var keycloakOptions = configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
-
-    c.AddSecurityDefinition(
-        "oidc",
-        new OpenApiSecurityScheme
+    options.AddDocumentTransformer(
+        (document, _, _) =>
         {
-            Name = "oauth2",
-            Type = SecuritySchemeType.OpenIdConnect,
-            OpenIdConnectUrl = new Uri(keycloakOptions.OpenIdConnectUrl!),
+            document.Components ??= new OpenApiComponents();
+            document.Components.SecuritySchemes ??=
+                new Dictionary<string, IOpenApiSecurityScheme>();
+            document.Components.SecuritySchemes[schemeName] = new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.OAuth2,
+                Flows = new OpenApiOAuthFlows
+                {
+                    AuthorizationCode = new OpenApiOAuthFlow
+                    {
+                        AuthorizationUrl = new Uri($"{realmUrl}protocol/openid-connect/auth"),
+                        TokenUrl = new Uri($"{realmUrl}protocol/openid-connect/token"),
+                        Scopes = new Dictionary<string, string>
+                        {
+                            ["openid"] = "OpenID",
+                            ["profile"] = "Profile",
+                        },
+                    },
+                },
+            };
+
+            document.Security =
+            [
+                new OpenApiSecurityRequirement
+                {
+                    [new OpenApiSecuritySchemeReference(schemeName, document)] = [],
+                },
+            ];
+
+            return Task.CompletedTask;
         }
     );
-
-    c.AddSecurityRequirement(document => new OpenApiSecurityRequirement
-    {
-        [new OpenApiSecuritySchemeReference("oidc", document)] = [],
-    });
-
-    c.SwaggerDoc("v1", new OpenApiInfo { Title = "API (v1)", Version = "v1" });
 });
 
 services.AddKeycloakWebApiAuthentication(
@@ -45,11 +67,18 @@ services.AddAuthorization();
 
 var app = builder.Build();
 
-app.UseSwagger();
-app.UseSwaggerUI(options =>
+app.MapOpenApi();
+app.UseSwaggerUi(options =>
 {
-    options.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
-    options.RoutePrefix = string.Empty;
+    options.DocumentPath = "/openapi/v1.json";
+    options.Path = string.Empty;
+    options.OAuth2Client = new OAuth2ClientSettings
+    {
+        ClientId = clientName,
+        AppName = clientName,
+        UsePkceWithAuthorizationCodeGrant = true,
+        Scopes = { "openid", "profile" },
+    };
 });
 
 app.UseHttpsRedirection();
@@ -57,6 +86,23 @@ app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapGet("/hello", () => "Hello World!").RequireAuthorization();
+app.MapGet(
+        "/hello",
+        (ClaimsPrincipal user) =>
+            new
+            {
+                message = "Hello World!",
+                name = user.Identity?.Name,
+                authenticationType = user.Identity?.AuthenticationType,
+                isAuthenticated = user.Identity?.IsAuthenticated ?? false,
+                claims = user.Claims.Select(c => new
+                {
+                    c.Type,
+                    c.Value,
+                    c.Issuer,
+                }),
+            }
+    )
+    .RequireAuthorization();
 
 app.Run();

--- a/samples/GettingStartedAndAspire/Api/Properties/launchSettings.json
+++ b/samples/GettingStartedAndAspire/Api/Properties/launchSettings.json
@@ -4,8 +4,8 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
+      "launchBrowser": false,
+      "launchUrl": "",
       "applicationUrl": "https://localhost:7107;http://localhost:5064",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/samples/GettingStartedAndAspire/AppHost/AppHost.csproj
+++ b/samples/GettingStartedAndAspire/AppHost/AppHost.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.2" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" />
     <PackageReference Include="Aspire.Hosting.AppHost" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/GettingStartedAndAspire/AppHost/KeycloakConfiguration/Test-realm.json
+++ b/samples/GettingStartedAndAspire/AppHost/KeycloakConfiguration/Test-realm.json
@@ -631,27 +631,27 @@
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "secret" : "ze4SQDpbyBlB72kdTCTv8ecSWsJHf2Js",
     "redirectUris" : [ "*" ],
     "webOrigins" : [ "*" ],
     "notBefore" : 0,
     "bearerOnly" : false,
     "consentRequired" : false,
     "standardFlowEnabled" : true,
-    "implicitFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
     "directAccessGrantsEnabled" : true,
-    "serviceAccountsEnabled" : true,
-    "authorizationServicesEnabled" : true,
-    "publicClient" : false,
+    "serviceAccountsEnabled" : false,
+    "authorizationServicesEnabled" : false,
+    "publicClient" : true,
     "frontchannelLogout" : true,
     "protocol" : "openid-connect",
     "attributes" : {
       "oidc.ciba.grant.enabled" : "false",
-      "client.secret.creation.time" : "1715201249",
       "backchannel.logout.session.required" : "true",
       "oauth2.device.authorization.grant.enabled" : "false",
       "display.on.consent.screen" : "false",
-      "backchannel.logout.revoke.offline.tokens" : "false"
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "pkce.code.challenge.method" : "S256",
+      "post.logout.redirect.uris" : "+"
     },
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
@@ -713,160 +713,7 @@
       }
     } ],
     "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
-    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ],
-    "authorizationSettings" : {
-      "allowRemoteResourceManagement" : true,
-      "policyEnforcementMode" : "ENFORCING",
-      "resources" : [ {
-        "name" : "workspaces",
-        "type" : "urn:workspaces",
-        "ownerManagedAccess" : false,
-        "displayName" : "",
-        "attributes" : { },
-        "_id" : "14b70534-d3f3-43ad-bdb4-99eb19e19b97",
-        "uris" : [ ],
-        "scopes" : [ {
-          "name" : "workspace:list"
-        }, {
-          "name" : "workspace:create"
-        } ],
-        "icon_uri" : ""
-      }, {
-        "name" : "workspaces__public",
-        "type" : "urn:workspaces",
-        "ownerManagedAccess" : false,
-        "attributes" : { },
-        "_id" : "581c2315-7097-4961-aa98-4ea1c0a808ef",
-        "uris" : [ ],
-        "scopes" : [ {
-          "name" : "workspace:list"
-        }, {
-          "name" : "workspace:add-user"
-        }, {
-          "name" : "workspace:create"
-        }, {
-          "name" : "workspace:remove-user"
-        }, {
-          "name" : "workspace:list-users"
-        }, {
-          "name" : "workspace:delete"
-        }, {
-          "name" : "workspace:read"
-        } ]
-      }, {
-        "name" : "workspaces__main",
-        "type" : "urn:workspaces",
-        "ownerManagedAccess" : true,
-        "attributes" : { },
-        "_id" : "3e23a12e-9ecd-4453-867d-760c7b296f0c",
-        "uris" : [ ],
-        "scopes" : [ {
-          "name" : "workspace:list"
-        }, {
-          "name" : "workspace:add-user"
-        }, {
-          "name" : "workspace:create"
-        }, {
-          "name" : "workspace:remove-user"
-        }, {
-          "name" : "workspace:list-users"
-        }, {
-          "name" : "workspace:delete"
-        }, {
-          "name" : "workspace:read"
-        } ]
-      } ],
-      "policies" : [ {
-        "id" : "303e03b1-f5bf-403f-bacc-578a5d62bc87",
-        "name" : "Is Admin",
-        "description" : "",
-        "type" : "role",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "UNANIMOUS",
-        "config" : {
-          "roles" : "[{\"id\":\"Admin\",\"required\":true}]"
-        }
-      }, {
-        "id" : "a14be734-9e9a-4ccb-a6ff-32bcb840b42e",
-        "name" : "Is Reader",
-        "description" : "",
-        "type" : "role",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "UNANIMOUS",
-        "config" : {
-          "roles" : "[{\"id\":\"Reader\",\"required\":true}]"
-        }
-      }, {
-        "id" : "9b546455-6ffb-4df7-9806-429b0b67f296",
-        "name" : "Can Create Workspace",
-        "description" : "",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "UNANIMOUS",
-        "config" : {
-          "resources" : "[\"workspaces\"]",
-          "scopes" : "[\"workspace:create\"]",
-          "applyPolicies" : "[\"Is Admin\"]"
-        }
-      }, {
-        "id" : "8535849b-d637-4a60-8b9a-3f045f3f23e9",
-        "name" : "Can List Workspaces",
-        "description" : "",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "AFFIRMATIVE",
-        "config" : {
-          "resources" : "[\"workspaces\"]",
-          "scopes" : "[\"workspace:list\"]",
-          "applyPolicies" : "[\"Is Admin\",\"Is Reader\"]"
-        }
-      }, {
-        "id" : "64782bb2-79bd-4904-8299-5012f66c2c85",
-        "name" : "Can Manage Workspaces",
-        "description" : "",
-        "type" : "scope",
-        "logic" : "POSITIVE",
-        "decisionStrategy" : "UNANIMOUS",
-        "config" : {
-          "defaultResourceType" : "urn:workspaces",
-          "applyPolicies" : "[\"Is Admin\"]",
-          "scopes" : "[\"workspace:delete\",\"workspace:read\",\"workspace:add-user\",\"workspace:remove-user\",\"workspace:list-users\"]"
-        }
-      } ],
-      "scopes" : [ {
-        "id" : "5e5817b9-23ec-4422-aa1c-521aedee90e2",
-        "name" : "workspace:read",
-        "iconUri" : ""
-      }, {
-        "id" : "bb5b4947-607e-4095-bec6-1b5350a3aa31",
-        "name" : "workspace:delete",
-        "iconUri" : ""
-      }, {
-        "id" : "5d8af7a9-ab34-4e35-842f-bd5e1c79ecf0",
-        "name" : "workspace:list",
-        "iconUri" : ""
-      }, {
-        "id" : "b838e1d0-f65b-41ca-a601-a442df709ffd",
-        "name" : "workspace:list-users",
-        "iconUri" : ""
-      }, {
-        "id" : "c4df45cf-8dee-48ce-afc1-ae595387c6a5",
-        "name" : "workspace:add-user",
-        "iconUri" : ""
-      }, {
-        "id" : "0f7ae0fb-2645-4ef0-9f1a-55e59d45ca97",
-        "name" : "workspace:remove-user",
-        "iconUri" : ""
-      }, {
-        "id" : "9e76de21-b0e7-43aa-b959-e72ec7d2d14e",
-        "name" : "workspace:create",
-        "iconUri" : ""
-      }, {
-        "id" : "e9ef9eae-7ff0-44d7-9052-dd884044485c",
-        "name" : "workspace:list-user"
-      } ],
-      "decisionStrategy" : "AFFIRMATIVE"
-    }
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   } ],
   "clientScopes" : [ {
     "id" : "f7d6e1fa-a7e0-48d7-baea-17a0c21158d9",

--- a/samples/GettingStartedAndAspire/AppHost/Program.cs
+++ b/samples/GettingStartedAndAspire/AppHost/Program.cs
@@ -1,8 +1,15 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+var postgres = builder
+    .AddPostgres("postgres")
+    .WithDataVolume()
+    .AddDatabase("keycloak-db", databaseName: "keycloak");
+
 var keycloak = builder
     .AddKeycloakContainer("keycloak")
     .WithDataVolume()
+    .WithHostname("http://localhost:8080/")
+    .WithPostgresDatabase(postgres)
     .WithImport("./KeycloakConfiguration/Test-realm.json")
     .WithImport("./KeycloakConfiguration/Test-users-0.json");
 

--- a/samples/GettingStartedAndAspire/AppHost/Program.cs
+++ b/samples/GettingStartedAndAspire/AppHost/Program.cs
@@ -1,8 +1,12 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+var pgUser = builder.AddParameter("pg-username", "postgres");
+var pgPassword = builder.AddParameter("pg-password", "postgres", secret: true);
+
 var postgres = builder
-    .AddPostgres("postgres")
+    .AddPostgres("postgres", pgUser, pgPassword)
     .WithDataVolume()
+    .WithLifetime(ContainerLifetime.Persistent)
     .AddDatabase("keycloak-db", databaseName: "keycloak");
 
 var keycloak = builder
@@ -10,6 +14,7 @@ var keycloak = builder
     .WithDataVolume()
     .WithHostname("http://localhost:8080/")
     .WithPostgresDatabase(postgres)
+    .WithOtlpExporter()
     .WithImport("./KeycloakConfiguration/Test-realm.json")
     .WithImport("./KeycloakConfiguration/Test-users-0.json");
 

--- a/samples/GettingStartedAndAspire/aspire.config.json
+++ b/samples/GettingStartedAndAspire/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "AppHost/AppHost.csproj"
+  }
+}

--- a/src/Keycloak.AuthServices.Aspire.Hosting/Keycloak.AuthServices.Aspire.Hosting.csproj
+++ b/src/Keycloak.AuthServices.Aspire.Hosting/Keycloak.AuthServices.Aspire.Hosting.csproj
@@ -8,7 +8,7 @@
     <Description>Aspire support for Keycloak</Description>
     <PackageTags>$(PackageTags);aspire;cloud-native</PackageTags>
     <MinVerSkip>true</MinVerSkip>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 

--- a/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakBuilderExtensions.cs
+++ b/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakBuilderExtensions.cs
@@ -214,32 +214,42 @@ public static class KeycloakBuilderExtensions
 
         builder.WaitFor(database);
 
-        return builder.WithEnvironment(async ctx =>
+        var settings = KeycloakDbReferenceBuilder.Build(vendor, database.Resource);
+
+        builder.WithEnvironment("KC_DB", settings.KcDb);
+        builder.WithEnvironment("KC_DB_URL", settings.JdbcUrl);
+        if (settings.Username is not null)
         {
-            var connectionString = await database.Resource.GetConnectionStringAsync(
-                ctx.CancellationToken
-            );
+            builder.WithEnvironment("KC_DB_USERNAME", settings.Username);
+        }
+        if (settings.Password is not null)
+        {
+            builder.WithEnvironment("KC_DB_PASSWORD", settings.Password);
+        }
 
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                throw new InvalidOperationException(
-                    $"Database resource '{database.Resource.Name}' did not provide a connection string."
-                );
-            }
+        return builder;
+    }
 
-            var settings = KeycloakDbConnectionStringTranslator.Translate(vendor, connectionString);
+    /// <summary>
+    /// Enables the Keycloak <c>opentelemetry</c> feature and configures the OTLP exporter so the
+    /// container forwards traces, metrics, and logs to the Aspire dashboard (or any OTLP collector
+    /// reachable via <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the official <c>Aspire.Hosting.Keycloak</c> behavior: sets <c>KC_FEATURES=opentelemetry</c>
+    /// and delegates to <see cref="OtlpConfigurationExtensions.WithOtlpExporter{T}(IResourceBuilder{T})"/>.
+    /// Requires Keycloak 25+ where the <c>opentelemetry</c> preview feature is available.
+    /// </remarks>
+    /// <param name="builder">The Keycloak resource builder.</param>
+    public static IResourceBuilder<KeycloakResource> WithOtlpExporter(
+        this IResourceBuilder<KeycloakResource> builder
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
 
-            ctx.EnvironmentVariables["KC_DB"] = settings.KcDb;
-            ctx.EnvironmentVariables["KC_DB_URL"] = settings.JdbcUrl;
-            if (settings.Username is not null)
-            {
-                ctx.EnvironmentVariables["KC_DB_USERNAME"] = settings.Username;
-            }
-            if (settings.Password is not null)
-            {
-                ctx.EnvironmentVariables["KC_DB_PASSWORD"] = settings.Password;
-            }
-        });
+        builder.WithEnvironment("KC_FEATURES", "opentelemetry");
+
+        return builder.WithOtlpExporter<KeycloakResource>();
     }
 
     /// <summary>

--- a/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakBuilderExtensions.cs
+++ b/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakBuilderExtensions.cs
@@ -140,6 +140,109 @@ public static class KeycloakBuilderExtensions
     }
 
     /// <summary>
+    /// Pins the Keycloak server hostname so issued tokens contain a stable <c>iss</c> claim,
+    /// regardless of which network identity (e.g. <c>localhost</c> vs. <c>host.docker.internal</c>)
+    /// the Keycloak container is reached on.
+    /// </summary>
+    /// <remarks>
+    /// Sets the <c>KC_HOSTNAME</c> environment variable. Use this when API consumers run inside
+    /// containers and need the issuer to match a single, fixed URL.
+    /// </remarks>
+    /// <param name="builder">The Keycloak resource builder.</param>
+    /// <param name="hostnameUrl">The hostname URL Keycloak should advertise (e.g. <c>http://localhost:8080/</c>).</param>
+    public static IResourceBuilder<KeycloakResource> WithHostname(
+        this IResourceBuilder<KeycloakResource> builder,
+        string hostnameUrl
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostnameUrl);
+
+        return builder.WithEnvironment("KC_HOSTNAME", hostnameUrl);
+    }
+
+    /// <summary>
+    /// Configures the Keycloak container to use an external PostgreSQL database for persistence.
+    /// </summary>
+    /// <param name="builder">The Keycloak resource builder.</param>
+    /// <param name="database">An Aspire database resource exposing a PostgreSQL connection string.</param>
+    public static IResourceBuilder<KeycloakResource> WithPostgresDatabase(
+        this IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database
+    ) => WithDatabaseCore(builder, database, KeycloakDbVendor.Postgres);
+
+    /// <summary>
+    /// Configures the Keycloak container to use an external MySQL database for persistence.
+    /// </summary>
+    public static IResourceBuilder<KeycloakResource> WithMySqlDatabase(
+        this IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database
+    ) => WithDatabaseCore(builder, database, KeycloakDbVendor.MySql);
+
+    /// <summary>
+    /// Configures the Keycloak container to use an external MariaDB database for persistence.
+    /// </summary>
+    public static IResourceBuilder<KeycloakResource> WithMariaDbDatabase(
+        this IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database
+    ) => WithDatabaseCore(builder, database, KeycloakDbVendor.MariaDb);
+
+    /// <summary>
+    /// Configures the Keycloak container to use an external Microsoft SQL Server database for persistence.
+    /// </summary>
+    public static IResourceBuilder<KeycloakResource> WithMsSqlDatabase(
+        this IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database
+    ) => WithDatabaseCore(builder, database, KeycloakDbVendor.MsSql);
+
+    /// <summary>
+    /// Configures the Keycloak container to use an external Oracle database for persistence.
+    /// </summary>
+    public static IResourceBuilder<KeycloakResource> WithOracleDatabase(
+        this IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database
+    ) => WithDatabaseCore(builder, database, KeycloakDbVendor.Oracle);
+
+    private static IResourceBuilder<KeycloakResource> WithDatabaseCore(
+        IResourceBuilder<KeycloakResource> builder,
+        IResourceBuilder<IResourceWithConnectionString> database,
+        KeycloakDbVendor vendor
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(database);
+
+        builder.WaitFor(database);
+
+        return builder.WithEnvironment(async ctx =>
+        {
+            var connectionString = await database.Resource.GetConnectionStringAsync(
+                ctx.CancellationToken
+            );
+
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException(
+                    $"Database resource '{database.Resource.Name}' did not provide a connection string."
+                );
+            }
+
+            var settings = KeycloakDbConnectionStringTranslator.Translate(vendor, connectionString);
+
+            ctx.EnvironmentVariables["KC_DB"] = settings.KcDb;
+            ctx.EnvironmentVariables["KC_DB_URL"] = settings.JdbcUrl;
+            if (settings.Username is not null)
+            {
+                ctx.EnvironmentVariables["KC_DB_USERNAME"] = settings.Username;
+            }
+            if (settings.Password is not null)
+            {
+                ctx.EnvironmentVariables["KC_DB_PASSWORD"] = settings.Password;
+            }
+        });
+    }
+
+    /// <summary>
     /// Adds a reference to a Keycloak resource to the specified resource builder.
     /// </summary>
     /// <typeparam name="TResource">The type of the resource builder.</typeparam>
@@ -172,5 +275,5 @@ internal static class KeycloakContainerImageTags
 {
     public const string Registry = "quay.io";
     public const string Image = "keycloak/keycloak";
-    public const string Tag = "26.3.3";
+    public const string Tag = "26.6.1";
 }

--- a/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakDbConnectionStringTranslator.cs
+++ b/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakDbConnectionStringTranslator.cs
@@ -1,6 +1,6 @@
 namespace Aspire.Hosting;
 
-using System.Data.Common;
+using Aspire.Hosting.ApplicationModel;
 
 internal enum KeycloakDbVendor
 {
@@ -11,147 +11,83 @@ internal enum KeycloakDbVendor
     Oracle,
 }
 
-internal static class KeycloakDbConnectionStringTranslator
+internal static class KeycloakDbReferenceBuilder
 {
-    public static KeycloakDbSettings Translate(KeycloakDbVendor vendor, string connectionString)
+    public static KeycloakDbSettings Build(
+        KeycloakDbVendor vendor,
+        IResourceWithConnectionString resource
+    )
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentNullException.ThrowIfNull(resource);
 
-        var parsed = new DbConnectionStringBuilder { ConnectionString = connectionString };
+        var props = new Dictionary<string, ReferenceExpression>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in resource.GetConnectionProperties())
+        {
+            props[kvp.Key] = kvp.Value;
+        }
+
+        var kcDb = vendor switch
+        {
+            KeycloakDbVendor.Postgres => "postgres",
+            KeycloakDbVendor.MySql => "mysql",
+            KeycloakDbVendor.MariaDb => "mariadb",
+            KeycloakDbVendor.MsSql => "mssql",
+            KeycloakDbVendor.Oracle => "oracle",
+            _ => throw new ArgumentOutOfRangeException(nameof(vendor)),
+        };
+
+        // Prefer resource-provided JDBC expression when available; it preserves
+        // container-network host/port resolution via the underlying endpoint references.
+        var url = props.TryGetValue("JdbcConnectionString", out var jdbc)
+            ? jdbc
+            : BuildUrlFromParts(vendor, props, resource.Name);
+
+        props.TryGetValue("Username", out var user);
+        props.TryGetValue("Password", out var pwd);
+
+        return new(kcDb, url, user, pwd);
+    }
+
+    private static ReferenceExpression BuildUrlFromParts(
+        KeycloakDbVendor vendor,
+        IReadOnlyDictionary<string, ReferenceExpression> props,
+        string resourceName
+    )
+    {
+        if (!props.TryGetValue("Host", out var host) || !props.TryGetValue("Port", out var port))
+        {
+            throw new InvalidOperationException(
+                $"Database resource '{resourceName}' did not expose 'Host'/'Port' connection properties required to build a Keycloak JDBC URL."
+            );
+        }
+
+        props.TryGetValue("DatabaseName", out var db);
 
         return vendor switch
         {
-            KeycloakDbVendor.Postgres => TranslatePostgres(parsed),
-            KeycloakDbVendor.MySql => TranslateMySqlLike(parsed, vendor: "mysql", scheme: "mysql"),
-            KeycloakDbVendor.MariaDb => TranslateMySqlLike(
-                parsed,
-                vendor: "mariadb",
-                scheme: "mariadb"
-            ),
-            KeycloakDbVendor.MsSql => TranslateMsSql(parsed),
-            KeycloakDbVendor.Oracle => TranslateOracle(parsed),
+            KeycloakDbVendor.Postgres => db is null
+                ? ReferenceExpression.Create($"jdbc:postgresql://{host}:{port}")
+                : ReferenceExpression.Create($"jdbc:postgresql://{host}:{port}/{db}"),
+            KeycloakDbVendor.MySql => db is null
+                ? ReferenceExpression.Create($"jdbc:mysql://{host}:{port}")
+                : ReferenceExpression.Create($"jdbc:mysql://{host}:{port}/{db}"),
+            KeycloakDbVendor.MariaDb => db is null
+                ? ReferenceExpression.Create($"jdbc:mariadb://{host}:{port}")
+                : ReferenceExpression.Create($"jdbc:mariadb://{host}:{port}/{db}"),
+            KeycloakDbVendor.MsSql => db is null
+                ? ReferenceExpression.Create($"jdbc:sqlserver://{host}:{port}")
+                : ReferenceExpression.Create($"jdbc:sqlserver://{host}:{port};databaseName={db}"),
+            KeycloakDbVendor.Oracle => db is null
+                ? ReferenceExpression.Create($"jdbc:oracle:thin:@//{host}:{port}")
+                : ReferenceExpression.Create($"jdbc:oracle:thin:@//{host}:{port}/{db}"),
             _ => throw new ArgumentOutOfRangeException(nameof(vendor)),
         };
-    }
-
-    private static KeycloakDbSettings TranslatePostgres(DbConnectionStringBuilder p)
-    {
-        var host = Get(p, "Host", "Server") ?? "localhost";
-        var port = Get(p, "Port") ?? "5432";
-        var database = Get(p, "Database");
-        var user = Get(p, "Username", "User Id", "User ID", "Uid");
-        var password = Get(p, "Password", "Pwd");
-
-        var url = database is null
-            ? $"jdbc:postgresql://{host}:{port}"
-            : $"jdbc:postgresql://{host}:{port}/{database}";
-
-        return new("postgres", url, user, password);
-    }
-
-    private static KeycloakDbSettings TranslateMySqlLike(
-        DbConnectionStringBuilder p,
-        string vendor,
-        string scheme
-    )
-    {
-        var host = Get(p, "Server", "Host", "Data Source") ?? "localhost";
-        var port = Get(p, "Port") ?? "3306";
-        var database = Get(p, "Database");
-        var user = Get(p, "Uid", "User Id", "User ID", "Username");
-        var password = Get(p, "Pwd", "Password");
-
-        var url = database is null
-            ? $"jdbc:{scheme}://{host}:{port}"
-            : $"jdbc:{scheme}://{host}:{port}/{database}";
-
-        return new(vendor, url, user, password);
-    }
-
-    private static KeycloakDbSettings TranslateMsSql(DbConnectionStringBuilder p)
-    {
-        var server = Get(p, "Server", "Data Source") ?? "localhost";
-        var (host, port) = SplitMsSqlServer(server);
-        var database = Get(p, "Database", "Initial Catalog");
-        var user = Get(p, "User Id", "User ID", "Uid", "Username");
-        var password = Get(p, "Password", "Pwd");
-
-        var url = $"jdbc:sqlserver://{host}:{port}";
-        if (!string.IsNullOrWhiteSpace(database))
-        {
-            url += $";databaseName={database}";
-        }
-
-        return new("mssql", url, user, password);
-    }
-
-    private static KeycloakDbSettings TranslateOracle(DbConnectionStringBuilder p)
-    {
-        var dataSource = Get(p, "Data Source", "Server") ?? "localhost:1521";
-        var (host, port, service) = SplitOracleDataSource(dataSource);
-        var user = Get(p, "User Id", "User ID", "Username", "Uid");
-        var password = Get(p, "Password", "Pwd");
-
-        var url = service is null
-            ? $"jdbc:oracle:thin:@//{host}:{port}"
-            : $"jdbc:oracle:thin:@//{host}:{port}/{service}";
-
-        return new("oracle", url, user, password);
-    }
-
-    private static (string Host, string Port) SplitMsSqlServer(string server)
-    {
-        var trimmed = server.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase)
-            ? server[4..]
-            : server;
-
-        var commaIdx = trimmed.IndexOf(',');
-        if (commaIdx >= 0)
-        {
-            return (trimmed[..commaIdx], trimmed[(commaIdx + 1)..]);
-        }
-
-        var colonIdx = trimmed.IndexOf(':');
-        if (colonIdx >= 0)
-        {
-            return (trimmed[..colonIdx], trimmed[(colonIdx + 1)..]);
-        }
-
-        return (trimmed, "1433");
-    }
-
-    private static (string Host, string Port, string? Service) SplitOracleDataSource(string source)
-    {
-        var slashIdx = source.IndexOf('/');
-        var hostPort = slashIdx >= 0 ? source[..slashIdx] : source;
-        var service = slashIdx >= 0 ? source[(slashIdx + 1)..] : null;
-
-        var colonIdx = hostPort.IndexOf(':');
-        if (colonIdx >= 0)
-        {
-            return (hostPort[..colonIdx], hostPort[(colonIdx + 1)..], service);
-        }
-
-        return (hostPort, "1521", service);
-    }
-
-    private static string? Get(DbConnectionStringBuilder p, params string[] keys)
-    {
-        foreach (var key in keys)
-        {
-            if (p.TryGetValue(key, out var value) && value is string s && !string.IsNullOrEmpty(s))
-            {
-                return s;
-            }
-        }
-
-        return null;
     }
 }
 
 internal readonly record struct KeycloakDbSettings(
     string KcDb,
-    string JdbcUrl,
-    string? Username,
-    string? Password
+    ReferenceExpression JdbcUrl,
+    ReferenceExpression? Username,
+    ReferenceExpression? Password
 );

--- a/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakDbConnectionStringTranslator.cs
+++ b/src/Keycloak.AuthServices.Aspire.Hosting/KeycloakDbConnectionStringTranslator.cs
@@ -1,0 +1,157 @@
+namespace Aspire.Hosting;
+
+using System.Data.Common;
+
+internal enum KeycloakDbVendor
+{
+    Postgres,
+    MySql,
+    MariaDb,
+    MsSql,
+    Oracle,
+}
+
+internal static class KeycloakDbConnectionStringTranslator
+{
+    public static KeycloakDbSettings Translate(KeycloakDbVendor vendor, string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        var parsed = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+        return vendor switch
+        {
+            KeycloakDbVendor.Postgres => TranslatePostgres(parsed),
+            KeycloakDbVendor.MySql => TranslateMySqlLike(parsed, vendor: "mysql", scheme: "mysql"),
+            KeycloakDbVendor.MariaDb => TranslateMySqlLike(
+                parsed,
+                vendor: "mariadb",
+                scheme: "mariadb"
+            ),
+            KeycloakDbVendor.MsSql => TranslateMsSql(parsed),
+            KeycloakDbVendor.Oracle => TranslateOracle(parsed),
+            _ => throw new ArgumentOutOfRangeException(nameof(vendor)),
+        };
+    }
+
+    private static KeycloakDbSettings TranslatePostgres(DbConnectionStringBuilder p)
+    {
+        var host = Get(p, "Host", "Server") ?? "localhost";
+        var port = Get(p, "Port") ?? "5432";
+        var database = Get(p, "Database");
+        var user = Get(p, "Username", "User Id", "User ID", "Uid");
+        var password = Get(p, "Password", "Pwd");
+
+        var url = database is null
+            ? $"jdbc:postgresql://{host}:{port}"
+            : $"jdbc:postgresql://{host}:{port}/{database}";
+
+        return new("postgres", url, user, password);
+    }
+
+    private static KeycloakDbSettings TranslateMySqlLike(
+        DbConnectionStringBuilder p,
+        string vendor,
+        string scheme
+    )
+    {
+        var host = Get(p, "Server", "Host", "Data Source") ?? "localhost";
+        var port = Get(p, "Port") ?? "3306";
+        var database = Get(p, "Database");
+        var user = Get(p, "Uid", "User Id", "User ID", "Username");
+        var password = Get(p, "Pwd", "Password");
+
+        var url = database is null
+            ? $"jdbc:{scheme}://{host}:{port}"
+            : $"jdbc:{scheme}://{host}:{port}/{database}";
+
+        return new(vendor, url, user, password);
+    }
+
+    private static KeycloakDbSettings TranslateMsSql(DbConnectionStringBuilder p)
+    {
+        var server = Get(p, "Server", "Data Source") ?? "localhost";
+        var (host, port) = SplitMsSqlServer(server);
+        var database = Get(p, "Database", "Initial Catalog");
+        var user = Get(p, "User Id", "User ID", "Uid", "Username");
+        var password = Get(p, "Password", "Pwd");
+
+        var url = $"jdbc:sqlserver://{host}:{port}";
+        if (!string.IsNullOrWhiteSpace(database))
+        {
+            url += $";databaseName={database}";
+        }
+
+        return new("mssql", url, user, password);
+    }
+
+    private static KeycloakDbSettings TranslateOracle(DbConnectionStringBuilder p)
+    {
+        var dataSource = Get(p, "Data Source", "Server") ?? "localhost:1521";
+        var (host, port, service) = SplitOracleDataSource(dataSource);
+        var user = Get(p, "User Id", "User ID", "Username", "Uid");
+        var password = Get(p, "Password", "Pwd");
+
+        var url = service is null
+            ? $"jdbc:oracle:thin:@//{host}:{port}"
+            : $"jdbc:oracle:thin:@//{host}:{port}/{service}";
+
+        return new("oracle", url, user, password);
+    }
+
+    private static (string Host, string Port) SplitMsSqlServer(string server)
+    {
+        var trimmed = server.StartsWith("tcp:", StringComparison.OrdinalIgnoreCase)
+            ? server[4..]
+            : server;
+
+        var commaIdx = trimmed.IndexOf(',');
+        if (commaIdx >= 0)
+        {
+            return (trimmed[..commaIdx], trimmed[(commaIdx + 1)..]);
+        }
+
+        var colonIdx = trimmed.IndexOf(':');
+        if (colonIdx >= 0)
+        {
+            return (trimmed[..colonIdx], trimmed[(colonIdx + 1)..]);
+        }
+
+        return (trimmed, "1433");
+    }
+
+    private static (string Host, string Port, string? Service) SplitOracleDataSource(string source)
+    {
+        var slashIdx = source.IndexOf('/');
+        var hostPort = slashIdx >= 0 ? source[..slashIdx] : source;
+        var service = slashIdx >= 0 ? source[(slashIdx + 1)..] : null;
+
+        var colonIdx = hostPort.IndexOf(':');
+        if (colonIdx >= 0)
+        {
+            return (hostPort[..colonIdx], hostPort[(colonIdx + 1)..], service);
+        }
+
+        return (hostPort, "1521", service);
+    }
+
+    private static string? Get(DbConnectionStringBuilder p, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (p.TryGetValue(key, out var value) && value is string s && !string.IsNullOrEmpty(s))
+            {
+                return s;
+            }
+        }
+
+        return null;
+    }
+}
+
+internal readonly record struct KeycloakDbSettings(
+    string KcDb,
+    string JdbcUrl,
+    string? Username,
+    string? Password
+);


### PR DESCRIPTION
## Summary

Modernizes `Keycloak.AuthServices.Aspire.Hosting` and ships two long-requested capabilities, replacing the open PRs that proposed them:

- **External database support** (closes #113) via vendor-typed extensions: `WithPostgresDatabase`, `WithMySqlDatabase`, `WithMariaDbDatabase`, `WithMsSqlDatabase`, `WithOracleDatabase`. Each translates the resolved Aspire connection string to Keycloak's `KC_DB` / `KC_DB_URL` / `KC_DB_USERNAME` / `KC_DB_PASSWORD` env vars at deploy time via `System.Data.Common.DbConnectionStringBuilder`. **No new package dependencies on the library** — `IResourceWithConnectionString` is the only contract used. Supersedes #230 (no adapter interface, supports publish/manifest mode correctly because the connection string is resolved via `GetConnectionStringAsync`).
- **Issuer pinning** (closes #115) via `WithHostname(url)` extension that sets `KC_HOSTNAME`, so issued tokens carry a stable `iss` claim regardless of how the container is reached. Solves the `localhost` ↔ `host.docker.internal` mismatch for containerized API consumers at the AppHost level. Supersedes #224 (a docs-only fix); the recipe content from #224 is also included for non-Aspire users.

### Other changes

- Bump default Keycloak image tag `26.3.3` → `26.6.1`.
- Bump package `VersionPrefix` `0.2.0` → `0.3.0`.
- Align sample AppHost `Aspire.AppHost.Sdk` `13.1.0` → `13.2.2`.
- Sample AppHost demonstrates `WithPostgresDatabase` + `WithHostname`.
- New docs sections in `docs/devex/aspire.md`: "Use an external database" and "Pin the issuer hostname".
- New recipe in `docs/qa/recipes.md`: "How to connect a containerized API to Keycloak?"

### Public API additions

```csharp
namespace Aspire.Hosting;

public static partial class KeycloakBuilderExtensions
{
    public static IResourceBuilder<KeycloakResource> WithHostname(
        this IResourceBuilder<KeycloakResource> builder, string hostnameUrl);

    public static IResourceBuilder<KeycloakResource> WithPostgresDatabase(
        this IResourceBuilder<KeycloakResource> builder,
        IResourceBuilder<IResourceWithConnectionString> database);

    public static IResourceBuilder<KeycloakResource> WithMySqlDatabase(...);
    public static IResourceBuilder<KeycloakResource> WithMariaDbDatabase(...);
    public static IResourceBuilder<KeycloakResource> WithMsSqlDatabase(...);
    public static IResourceBuilder<KeycloakResource> WithOracleDatabase(...);
}
```

## Test plan

- [x] `dotnet build KeycloakAuthorizationServicesDotNet.slnx` — 0 errors
- [x] Unit tests pass: 22 (Authentication) + 146 (Authorization) + 9 (Common) + 75 (Sdk) = **252 passed**
- [x] Connection-string translator smoke-tested across all 6 cases (Postgres, MySql, MariaDB, MsSql with port, MsSql with `tcp:` prefix, Oracle) — produces correct JDBC URLs
- [x] `aspire start --isolated` from `samples/GettingStartedAndAspire/AppHost` — verify `KC_DB`/`KC_DB_URL`/`KC_DB_USERNAME`/`KC_DB_PASSWORD` resolve and Keycloak boots against Postgres (requires Docker; not run in the dev env where this branch was prepared)
- [x] Decode an issued token's `iss` claim — confirm matches `WithHostname` value
- [x] Spot-check publish mode — confirm `KC_DB_PASSWORD` resolves through `ReferenceExpression` semantics, not literal value

## Follow-ups

- New issue: add test coverage for `Keycloak.AuthServices.Aspire.Hosting` using `Aspire.Hosting.Testing.DistributedApplicationTestingBuilder`.
- Close #224 and #230 as superseded.