### PR TITLE
Add support for Keycloak organizations API

### DIFF
--- a/src/Keycloak.AuthServices.Sdk/Admin/ApiUrls.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/ApiUrls.cs
@@ -63,6 +63,36 @@ internal static class ApiUrls
 
     #endregion
 
+    #region Organization API
+
+    internal const string GetOrganizations = $"{GetRealm}/organizations";
+
+    internal const string CreateOrganization = $"{GetRealm}/organizations";
+
+    internal const string GetOrganizationCount = $"{GetRealm}/organizations/count";
+
+    internal const string GetOrganization = $"{GetRealm}/organizations/{{id}}";
+
+    internal const string UpdateOrganization = $"{GetRealm}/organizations/{{id}}";
+
+    internal const string DeleteOrganization = $"{GetRealm}/organizations/{{id}}";
+
+    internal const string GetOrganizationMembers = $"{GetRealm}/organizations/{{id}}/members";
+
+    internal const string AddOrganizationMember = $"{GetRealm}/organizations/{{id}}/members";
+
+    internal const string GetOrganizationMemberCount = $"{GetRealm}/organizations/{{id}}/members/count";
+
+    internal const string GetOrganizationMember = $"{GetRealm}/organizations/{{id}}/members/{{memberId}}";
+
+    internal const string RemoveOrganizationMember = $"{GetRealm}/organizations/{{id}}/members/{{memberId}}";
+
+    internal const string GetOrganizationMemberGroups = $"{GetRealm}/organizations/{{id}}/members/{{memberId}}/groups";
+
+    internal const string GetUserOrganizations = $"{GetRealm}/organizations/members/{{memberId}}/organizations";
+
+    #endregion
+
     public static string WithRealm(this string path, string realm) =>
         path.Replace(RealmParam, realm);
 }

--- a/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakClient.cs
@@ -9,4 +9,5 @@ namespace Keycloak.AuthServices.Sdk.Admin;
 public interface IKeycloakClient
     : IKeycloakRealmClient,
         IKeycloakUserClient,
-        IKeycloakGroupClient { }
+        IKeycloakGroupClient,
+        IKeycloakOrganizationClient { }

--- a/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakOrganizationClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakOrganizationClient.cs
@@ -3,257 +3,460 @@ namespace Keycloak.AuthServices.Sdk.Admin;
 using Keycloak.AuthServices.Sdk.Admin.Models;
 using Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
 
-
 /// <summary>
 /// Keycloak Organizations management.
 /// </summary>
 public interface IKeycloakOrganizationClient
 {
-    // ==============================================================
-    // Organization CRUD
-    // ==============================================================
-
-    /// <summary>Returns a paginated list of organizations filtered by the given parameters.</summary>
-    Task<HttpResponseMessage> GetOrganizationsWithResponseAsync(
+    /// <summary>
+    /// Returns a paginated list of organizations filtered by the given parameters.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="parameters">Optional query parameters.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A paginated list of organizations.</returns>
+    public Task<HttpResponseMessage> GetOrganizationsWithResponseAsync(
         string realm,
         GetOrganizationsRequestParameters? parameters = default,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationsWithResponseAsync"/>
+    /// <summary>
+    /// Returns a paginated list of organizations filtered by the given parameters.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="parameters">Optional query parameters.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A paginated list of organizations.</returns>
     public async Task<IEnumerable<OrganizationRepresentation>> GetOrganizationsAsync(
         string realm,
         GetOrganizationsRequestParameters? parameters = default,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationsWithResponseAsync(realm, parameters, cancellationToken);
+
         return await response.GetResponseAsync<IEnumerable<OrganizationRepresentation>>(cancellationToken)
             ?? Enumerable.Empty<OrganizationRepresentation>();
     }
 
-    /// <summary>Returns the total organization count for the realm.</summary>
-    Task<HttpResponseMessage> GetOrganizationCountWithResponseAsync(
+    /// <summary>
+    /// Returns the total organization count for the realm.
+    ///
+    /// Note that the response is not JSON, but simply the integer value as a string.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>An integer amount of organizations.</returns>
+    public Task<HttpResponseMessage> GetOrganizationCountWithResponseAsync(
         string realm,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationCountWithResponseAsync"/>
-    public async Task<long> GetOrganizationCountAsync(
+    /// <summary>
+    /// Returns the total organization count for the realm.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>An integer amount of organizations.</returns>
+    public async Task<int> GetOrganizationCountAsync(
         string realm,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationCountWithResponseAsync(realm, cancellationToken);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var stringContent = await response.Content.ReadAsStringAsync(cancellationToken);
 #pragma warning disable CA1305 // Specify IFormatProvider
-        return Convert.ToInt64(content);
+        return Convert.ToInt32(stringContent);
 #pragma warning restore CA1305 // Specify IFormatProvider
     }
 
-    /// <summary>Returns the representation of the organization with the given id.</summary>
-    Task<HttpResponseMessage> GetOrganizationWithResponseAsync(
+    /// <summary>
+    /// Returns the representation of the organization with the given id.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The organization representation.</returns>
+    public Task<HttpResponseMessage> GetOrganizationWithResponseAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationWithResponseAsync"/>
+    /// <summary>
+    /// Returns the representation of the organization with the given id.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The organization representation.</returns>
     public async Task<OrganizationRepresentation> GetOrganizationAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationWithResponseAsync(realm, orgId, cancellationToken);
+
         return await response.GetResponseAsync<OrganizationRepresentation>(cancellationToken) ?? new();
     }
 
-    /// <summary>Creates a new organization.</summary>
-    Task<HttpResponseMessage> CreateOrganizationWithResponseAsync(
+    /// <summary>
+    /// Creates a new organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="organization">Organization representation.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<HttpResponseMessage> CreateOrganizationWithResponseAsync(
         string realm,
         OrganizationRepresentation organization,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="CreateOrganizationWithResponseAsync"/>
+    /// <summary>
+    /// Creates a new organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="organization">Organization representation.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task CreateOrganizationAsync(
         string realm,
         OrganizationRepresentation organization,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.CreateOrganizationWithResponseAsync(realm, organization, cancellationToken);
+
         await response.EnsureResponseAsync(cancellationToken);
     }
 
-    /// <summary>Updates the organization.</summary>
-    Task<HttpResponseMessage> UpdateOrganizationWithResponseAsync(
+    /// <summary>
+    /// Updates the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="organization">Organization representation.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<HttpResponseMessage> UpdateOrganizationWithResponseAsync(
         string realm,
         string orgId,
         OrganizationRepresentation organization,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="UpdateOrganizationWithResponseAsync"/>
+    /// <summary>
+    /// Updates the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="organization">Organization representation.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task UpdateOrganizationAsync(
         string realm,
         string orgId,
         OrganizationRepresentation organization,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.UpdateOrganizationWithResponseAsync(realm, orgId, organization, cancellationToken);
+
         await response.EnsureResponseAsync(cancellationToken);
     }
 
-    /// <summary>Deletes the organization.</summary>
-    Task<HttpResponseMessage> DeleteOrganizationWithResponseAsync(
+    /// <summary>
+    /// Deletes the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<HttpResponseMessage> DeleteOrganizationWithResponseAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="DeleteOrganizationWithResponseAsync"/>
+    /// <summary>
+    /// Deletes the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task DeleteOrganizationAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.DeleteOrganizationWithResponseAsync(realm, orgId, cancellationToken);
+
         await response.EnsureResponseAsync(cancellationToken);
     }
 
-    // ==============================================================
-    // Members
-    // ==============================================================
-
-    /// <summary>Returns a paginated list of members of the organization.</summary>
-    Task<HttpResponseMessage> GetOrganizationMembersWithResponseAsync(
+    /// <summary>
+    /// Returns a paginated list of members of the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="parameters">Optional query parameters.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A paginated list of organization members.</returns>
+    public Task<HttpResponseMessage> GetOrganizationMembersWithResponseAsync(
         string realm,
         string orgId,
         GetOrganizationMembersRequestParameters? parameters = default,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationMembersWithResponseAsync"/>
+    /// <summary>
+    /// Returns a paginated list of members of the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="parameters">Optional query parameters.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A paginated list of organization members.</returns>
     public async Task<IEnumerable<OrganizationMemberRepresentation>> GetOrganizationMembersAsync(
         string realm,
         string orgId,
         GetOrganizationMembersRequestParameters? parameters = default,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationMembersWithResponseAsync(realm, orgId, parameters, cancellationToken);
+
         return await response.GetResponseAsync<IEnumerable<OrganizationMemberRepresentation>>(cancellationToken)
             ?? Enumerable.Empty<OrganizationMemberRepresentation>();
     }
 
-    /// <summary>Returns the total member count for the organization.</summary>
-    Task<HttpResponseMessage> GetOrganizationMemberCountWithResponseAsync(
+    /// <summary>
+    /// Returns the total member count for the organization.
+    ///
+    /// Note that the response is not JSON, but simply the integer value as a string.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>An integer amount of members.</returns>
+    public Task<HttpResponseMessage> GetOrganizationMemberCountWithResponseAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationMemberCountWithResponseAsync"/>
-    public async Task<long> GetOrganizationMemberCountAsync(
+    /// <summary>
+    /// Returns the total member count for the organization.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>An integer amount of members.</returns>
+    public async Task<int> GetOrganizationMemberCountAsync(
         string realm,
         string orgId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationMemberCountWithResponseAsync(realm, orgId, cancellationToken);
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-#pragma warning disable CA1305
-        return Convert.ToInt64(content);
-#pragma warning restore CA1305
+        var stringContent = await response.Content.ReadAsStringAsync(cancellationToken);
+#pragma warning disable CA1305 // Specify IFormatProvider
+        return Convert.ToInt32(stringContent);
+#pragma warning restore CA1305 // Specify IFormatProvider
     }
 
-    /// <summary>Returns the representation of the given member.</summary>
-    Task<HttpResponseMessage> GetOrganizationMemberWithResponseAsync(
+    /// <summary>
+    /// Get representation of the given member.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The member representation.</returns>
+    public Task<HttpResponseMessage> GetOrganizationMemberWithResponseAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationMemberWithResponseAsync"/>
+    /// <summary>
+    /// Get representation of the given member.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>The member representation.</returns>
     public async Task<OrganizationMemberRepresentation> GetOrganizationMemberAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationMemberWithResponseAsync(realm, orgId, memberId, cancellationToken);
+
         return await response.GetResponseAsync<OrganizationMemberRepresentation>(cancellationToken) ?? new();
     }
 
     /// <summary>
-    /// Adds (associates) an existing realm user to the organization. If no user is found,
-    /// or if the user is already a member, Keycloak returns an error response.
+    /// Adds (associates) an existing realm user to the organization.
     /// </summary>
-    Task<HttpResponseMessage> AddOrganizationMemberWithResponseAsync(
+    /// <remarks>
+    /// If no user is found, or if the user is already a member, Keycloak returns an error response.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="userId">User ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<HttpResponseMessage> AddOrganizationMemberWithResponseAsync(
         string realm,
         string orgId,
         string userId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="AddOrganizationMemberWithResponseAsync"/>
+    /// <summary>
+    /// Adds (associates) an existing realm user to the organization.
+    /// </summary>
+    /// <remarks>
+    /// If no user is found, or if the user is already a member, Keycloak returns an error response.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="userId">User ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task AddOrganizationMemberAsync(
         string realm,
         string orgId,
         string userId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.AddOrganizationMemberWithResponseAsync(realm, orgId, userId, cancellationToken);
+
         await response.EnsureResponseAsync(cancellationToken);
     }
 
     /// <summary>
-    /// Removes the user from the organization. For managed members the user is deleted;
-    /// for unmanaged members only the association is removed.
+    /// Removes the user from the organization.
     /// </summary>
-    Task<HttpResponseMessage> RemoveOrganizationMemberWithResponseAsync(
+    /// <remarks>
+    /// For managed members the user is deleted; for unmanaged members only the association is removed.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Task<HttpResponseMessage> RemoveOrganizationMemberWithResponseAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="RemoveOrganizationMemberWithResponseAsync"/>
+    /// <summary>
+    /// Removes the user from the organization.
+    /// </summary>
+    /// <remarks>
+    /// For managed members the user is deleted; for unmanaged members only the association is removed.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
     public async Task RemoveOrganizationMemberAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.RemoveOrganizationMemberWithResponseAsync(realm, orgId, memberId, cancellationToken);
+
         await response.EnsureResponseAsync(cancellationToken);
     }
 
-    // ==============================================================
-    // Member sub-resources
-    // ==============================================================
-
     /// <summary>
     /// Returns the groups within this organization that the given member belongs to.
-    /// Returns 404 if the user is not a member of the organization.
     /// </summary>
-    Task<HttpResponseMessage> GetOrganizationMemberGroupsWithResponseAsync(
+    /// <remarks>
+    /// Returns 404 if the user is not a member of the organization.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A list of group representations.</returns>
+    public Task<HttpResponseMessage> GetOrganizationMemberGroupsWithResponseAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetOrganizationMemberGroupsWithResponseAsync"/>
+    /// <summary>
+    /// Returns the groups within this organization that the given member belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Returns 404 if the user is not a member of the organization.
+    /// </remarks>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="orgId">Organization ID.</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A list of group representations.</returns>
     public async Task<IEnumerable<GroupRepresentation>> GetOrganizationMemberGroupsAsync(
         string realm,
         string orgId,
         string memberId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetOrganizationMemberGroupsWithResponseAsync(realm, orgId, memberId, cancellationToken);
+
         return await response.GetResponseAsync<IEnumerable<GroupRepresentation>>(cancellationToken)
             ?? Enumerable.Empty<GroupRepresentation>();
     }
 
-    /// <summary>Returns the organizations that the user with the specified id belongs to.</summary>
-    Task<HttpResponseMessage> GetUserOrganizationsWithResponseAsync(
+    /// <summary>
+    /// Returns the organizations that the user with the specified id belongs to.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A list of organizations.</returns>
+    public Task<HttpResponseMessage> GetUserOrganizationsWithResponseAsync(
         string realm,
         string memberId,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default
+    );
 
-    /// <inheritdoc cref="GetUserOrganizationsWithResponseAsync"/>
+    /// <summary>
+    /// Returns the organizations that the user with the specified id belongs to.
+    /// </summary>
+    /// <param name="realm">Realm name (not ID).</param>
+    /// <param name="memberId">Member ID.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>A list of organizations.</returns>
     public async Task<IEnumerable<OrganizationRepresentation>> GetUserOrganizationsAsync(
         string realm,
         string memberId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
     {
         var response = await this.GetUserOrganizationsWithResponseAsync(realm, memberId, cancellationToken);
+
         return await response.GetResponseAsync<IEnumerable<OrganizationRepresentation>>(cancellationToken)
             ?? Enumerable.Empty<OrganizationRepresentation>();
     }

--- a/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakOrganizationClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/IKeycloakOrganizationClient.cs
@@ -1,0 +1,260 @@
+namespace Keycloak.AuthServices.Sdk.Admin;
+
+using Keycloak.AuthServices.Sdk.Admin.Models;
+using Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
+
+
+/// <summary>
+/// Keycloak Organizations management.
+/// </summary>
+public interface IKeycloakOrganizationClient
+{
+    // ==============================================================
+    // Organization CRUD
+    // ==============================================================
+
+    /// <summary>Returns a paginated list of organizations filtered by the given parameters.</summary>
+    Task<HttpResponseMessage> GetOrganizationsWithResponseAsync(
+        string realm,
+        GetOrganizationsRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationsWithResponseAsync"/>
+    public async Task<IEnumerable<OrganizationRepresentation>> GetOrganizationsAsync(
+        string realm,
+        GetOrganizationsRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationsWithResponseAsync(realm, parameters, cancellationToken);
+        return await response.GetResponseAsync<IEnumerable<OrganizationRepresentation>>(cancellationToken)
+            ?? Enumerable.Empty<OrganizationRepresentation>();
+    }
+
+    /// <summary>Returns the total organization count for the realm.</summary>
+    Task<HttpResponseMessage> GetOrganizationCountWithResponseAsync(
+        string realm,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationCountWithResponseAsync"/>
+    public async Task<long> GetOrganizationCountAsync(
+        string realm,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationCountWithResponseAsync(realm, cancellationToken);
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+#pragma warning disable CA1305 // Specify IFormatProvider
+        return Convert.ToInt64(content);
+#pragma warning restore CA1305 // Specify IFormatProvider
+    }
+
+    /// <summary>Returns the representation of the organization with the given id.</summary>
+    Task<HttpResponseMessage> GetOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationWithResponseAsync"/>
+    public async Task<OrganizationRepresentation> GetOrganizationAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationWithResponseAsync(realm, orgId, cancellationToken);
+        return await response.GetResponseAsync<OrganizationRepresentation>(cancellationToken) ?? new();
+    }
+
+    /// <summary>Creates a new organization.</summary>
+    Task<HttpResponseMessage> CreateOrganizationWithResponseAsync(
+        string realm,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="CreateOrganizationWithResponseAsync"/>
+    public async Task CreateOrganizationAsync(
+        string realm,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.CreateOrganizationWithResponseAsync(realm, organization, cancellationToken);
+        await response.EnsureResponseAsync(cancellationToken);
+    }
+
+    /// <summary>Updates the organization.</summary>
+    Task<HttpResponseMessage> UpdateOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="UpdateOrganizationWithResponseAsync"/>
+    public async Task UpdateOrganizationAsync(
+        string realm,
+        string orgId,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.UpdateOrganizationWithResponseAsync(realm, orgId, organization, cancellationToken);
+        await response.EnsureResponseAsync(cancellationToken);
+    }
+
+    /// <summary>Deletes the organization.</summary>
+    Task<HttpResponseMessage> DeleteOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="DeleteOrganizationWithResponseAsync"/>
+    public async Task DeleteOrganizationAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.DeleteOrganizationWithResponseAsync(realm, orgId, cancellationToken);
+        await response.EnsureResponseAsync(cancellationToken);
+    }
+
+    // ==============================================================
+    // Members
+    // ==============================================================
+
+    /// <summary>Returns a paginated list of members of the organization.</summary>
+    Task<HttpResponseMessage> GetOrganizationMembersWithResponseAsync(
+        string realm,
+        string orgId,
+        GetOrganizationMembersRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationMembersWithResponseAsync"/>
+    public async Task<IEnumerable<OrganizationMemberRepresentation>> GetOrganizationMembersAsync(
+        string realm,
+        string orgId,
+        GetOrganizationMembersRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationMembersWithResponseAsync(realm, orgId, parameters, cancellationToken);
+        return await response.GetResponseAsync<IEnumerable<OrganizationMemberRepresentation>>(cancellationToken)
+            ?? Enumerable.Empty<OrganizationMemberRepresentation>();
+    }
+
+    /// <summary>Returns the total member count for the organization.</summary>
+    Task<HttpResponseMessage> GetOrganizationMemberCountWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationMemberCountWithResponseAsync"/>
+    public async Task<long> GetOrganizationMemberCountAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationMemberCountWithResponseAsync(realm, orgId, cancellationToken);
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+#pragma warning disable CA1305
+        return Convert.ToInt64(content);
+#pragma warning restore CA1305
+    }
+
+    /// <summary>Returns the representation of the given member.</summary>
+    Task<HttpResponseMessage> GetOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationMemberWithResponseAsync"/>
+    public async Task<OrganizationMemberRepresentation> GetOrganizationMemberAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationMemberWithResponseAsync(realm, orgId, memberId, cancellationToken);
+        return await response.GetResponseAsync<OrganizationMemberRepresentation>(cancellationToken) ?? new();
+    }
+
+    /// <summary>
+    /// Adds (associates) an existing realm user to the organization. If no user is found,
+    /// or if the user is already a member, Keycloak returns an error response.
+    /// </summary>
+    Task<HttpResponseMessage> AddOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string userId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="AddOrganizationMemberWithResponseAsync"/>
+    public async Task AddOrganizationMemberAsync(
+        string realm,
+        string orgId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.AddOrganizationMemberWithResponseAsync(realm, orgId, userId, cancellationToken);
+        await response.EnsureResponseAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Removes the user from the organization. For managed members the user is deleted;
+    /// for unmanaged members only the association is removed.
+    /// </summary>
+    Task<HttpResponseMessage> RemoveOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="RemoveOrganizationMemberWithResponseAsync"/>
+    public async Task RemoveOrganizationMemberAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.RemoveOrganizationMemberWithResponseAsync(realm, orgId, memberId, cancellationToken);
+        await response.EnsureResponseAsync(cancellationToken);
+    }
+
+    // ==============================================================
+    // Member sub-resources
+    // ==============================================================
+
+    /// <summary>
+    /// Returns the groups within this organization that the given member belongs to.
+    /// Returns 404 if the user is not a member of the organization.
+    /// </summary>
+    Task<HttpResponseMessage> GetOrganizationMemberGroupsWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetOrganizationMemberGroupsWithResponseAsync"/>
+    public async Task<IEnumerable<GroupRepresentation>> GetOrganizationMemberGroupsAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetOrganizationMemberGroupsWithResponseAsync(realm, orgId, memberId, cancellationToken);
+        return await response.GetResponseAsync<IEnumerable<GroupRepresentation>>(cancellationToken)
+            ?? Enumerable.Empty<GroupRepresentation>();
+    }
+
+    /// <summary>Returns the organizations that the user with the specified id belongs to.</summary>
+    Task<HttpResponseMessage> GetUserOrganizationsWithResponseAsync(
+        string realm,
+        string memberId,
+        CancellationToken cancellationToken = default);
+
+    /// <inheritdoc cref="GetUserOrganizationsWithResponseAsync"/>
+    public async Task<IEnumerable<OrganizationRepresentation>> GetUserOrganizationsAsync(
+        string realm,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await this.GetUserOrganizationsWithResponseAsync(realm, memberId, cancellationToken);
+        return await response.GetResponseAsync<IEnumerable<OrganizationRepresentation>>(cancellationToken)
+            ?? Enumerable.Empty<OrganizationRepresentation>();
+    }
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/KeycloakClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/KeycloakClient.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http.Json;
 using Keycloak.AuthServices.Sdk.Admin.Models;
+using Keycloak.AuthServices.Sdk.Admin.Requests.Groups;
 using Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
 using Keycloak.AuthServices.Sdk.Admin.Requests.Users;
 using Keycloak.AuthServices.Sdk.Utils;
@@ -793,3 +794,4 @@ public class KeycloakClient : IKeycloakClient
     }
 
     #endregion
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/KeycloakClient.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/KeycloakClient.cs
@@ -1,10 +1,11 @@
 namespace Keycloak.AuthServices.Sdk.Admin;
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http.Json;
 using Keycloak.AuthServices.Sdk.Admin.Models;
-using Keycloak.AuthServices.Sdk.Admin.Requests.Groups;
+using Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
 using Keycloak.AuthServices.Sdk.Admin.Requests.Users;
 using Keycloak.AuthServices.Sdk.Utils;
 
@@ -548,4 +549,247 @@ public class KeycloakClient : IKeycloakClient
     }
 
     #endregion
-}
+
+    #region OrganizationRegion
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationsWithResponseAsync(
+        string realm,
+        GetOrganizationsRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var path = ApiUrls.GetOrganizations.WithRealm(realm);
+
+        var queryBuilder = new QueryBuilder();
+
+        parameters ??= new();
+        if (parameters.BriefRepresentation.HasValue)
+        {
+            queryBuilder.Add("briefRepresentation", parameters.BriefRepresentation?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.Exact.HasValue)
+        {
+            queryBuilder.Add("exact", parameters.Exact?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.First.HasValue)
+        {
+            queryBuilder.Add("first", parameters.First?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.Max.HasValue)
+        {
+            queryBuilder.Add("max", parameters.Max?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.Query is not null)
+        {
+            queryBuilder.Add("q", parameters.Query.ToString()!);
+        }
+
+        if (parameters.Search is not null)
+        {
+            queryBuilder.Add("search", parameters.Search.ToString()!);
+        }
+
+        var url = path + queryBuilder.ToQueryString();
+
+        var responseMessage = await this.httpClient.GetAsync(url, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationCountWithResponseAsync(
+        string realm,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganizationCount.WithRealm(realm);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganization.WithRealm(realm).Replace("{id}", orgId);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> CreateOrganizationWithResponseAsync(
+        string realm,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.CreateOrganization.WithRealm(realm);
+
+        var responseMessage = await this.httpClient.PostAsJsonAsync(path, organization, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> UpdateOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        OrganizationRepresentation organization,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.UpdateOrganization.WithRealm(realm).Replace("{id}", orgId);
+
+        var responseMessage = await this.httpClient.PutAsJsonAsync(path, organization, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> DeleteOrganizationWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.DeleteOrganization.WithRealm(realm).Replace("{id}", orgId);
+
+        var responseMessage = await this.httpClient.DeleteAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationMembersWithResponseAsync(
+        string realm,
+        string orgId,
+        GetOrganizationMembersRequestParameters? parameters = default,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganizationMembers.WithRealm(realm).Replace("{id}", orgId);
+
+        var queryBuilder = new QueryBuilder();
+
+        parameters ??= new();
+        if (parameters.Exact.HasValue)
+        {
+            queryBuilder.Add("exact", parameters.Exact?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.First.HasValue)
+        {
+            queryBuilder.Add("first", parameters.First?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.Max.HasValue)
+        {
+            queryBuilder.Add("max", parameters.Max?.ToString(CultureInfo.InvariantCulture)!);
+        }
+
+        if (parameters.MembershipType is not null)
+        {
+            queryBuilder.Add("membershipType", parameters.MembershipType.ToString()!);
+        }
+
+        if (parameters.Search is not null)
+        {
+            queryBuilder.Add("search", parameters.Search.ToString()!);
+        }
+
+        var url = path + queryBuilder.ToQueryString();
+
+        var responseMessage = await this.httpClient.GetAsync(url, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationMemberCountWithResponseAsync(
+        string realm,
+        string orgId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganizationMemberCount.WithRealm(realm).Replace("{id}", orgId);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganizationMember.WithRealm(realm).Replace("{id}", orgId).Replace("{memberId}", memberId);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> AddOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.AddOrganizationMember.WithRealm(realm).Replace("{id}", orgId);
+
+        var responseMessage = await this.httpClient.PostAsJsonAsync(path, userId, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> RemoveOrganizationMemberWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.RemoveOrganizationMember.WithRealm(realm).Replace("{id}", orgId).Replace("{memberId}", memberId);
+
+        var responseMessage = await this.httpClient.DeleteAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetOrganizationMemberGroupsWithResponseAsync(
+        string realm,
+        string orgId,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetOrganizationMemberGroups.WithRealm(realm).Replace("{id}", orgId).Replace("{memberId}", memberId);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HttpResponseMessage> GetUserOrganizationsWithResponseAsync(
+        string realm,
+        string memberId,
+        CancellationToken cancellationToken = default)
+    {
+        var path = ApiUrls.GetUserOrganizations.WithRealm(realm).Replace("{memberId}", memberId);
+
+        var responseMessage = await this.httpClient.GetAsync(path, cancellationToken);
+
+        return responseMessage!;
+    }
+
+    #endregion

--- a/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationDomainRepresentation.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationDomainRepresentation.cs
@@ -1,0 +1,17 @@
+namespace Keycloak.AuthServices.Sdk.Admin.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Representation of a domain associated with a Keycloak organization.
+/// </summary>
+public class OrganizationDomainRepresentation
+{
+    /// <summary>The domain name (e.g. <c>example.com</c>).</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Whether the domain has been verified.</summary>
+    [JsonPropertyName("verified")]
+    public bool Verified { get; set; }
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationMemberRepresentation.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationMemberRepresentation.cs
@@ -1,0 +1,40 @@
+namespace Keycloak.AuthServices.Sdk.Admin.Models;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Representation of a user's membership in a Keycloak organization.
+/// </summary>
+public class OrganizationMemberRepresentation
+{
+    /// <summary>User id (matches the id on <c>UserRepresentation</c>).</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Username.</summary>
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>Email address.</summary>
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>Given name.</summary>
+    [JsonPropertyName("firstName")]
+    public string? FirstName { get; set; }
+
+    /// <summary>Family name.</summary>
+    [JsonPropertyName("lastName")]
+    public string? LastName { get; set; }
+
+    /// <summary>Whether the user account is enabled.</summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Type of membership. Keycloak defines <c>MANAGED</c> and <c>UNMANAGED</c> —
+    /// managed users are auto-created and are deleted when they leave the organization.
+    /// </summary>
+    [JsonPropertyName("membershipType")]
+    public string? MembershipType { get; set; }
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationRepresentation.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Models/OrganizationRepresentation.cs
@@ -1,0 +1,42 @@
+namespace Keycloak.AuthServices.Sdk.Admin.Models;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Representation of a Keycloak organization.
+/// </summary>
+public class OrganizationRepresentation
+{
+    /// <summary>Unique identifier of the organization.</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Display name of the organization.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>URL-friendly alias for the organization.</summary>
+    [JsonPropertyName("alias")]
+    public string? Alias { get; set; }
+
+    /// <summary>Whether the organization is enabled.</summary>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    /// <summary>Optional description.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>Optional redirect URL used during organization onboarding flows.</summary>
+    [JsonPropertyName("redirectUrl")]
+    public string? RedirectUrl { get; set; }
+
+    /// <summary>Free-form attributes.</summary>
+    [JsonPropertyName("attributes")]
+    public IDictionary<string, IEnumerable<string>>? Attributes { get; set; }
+
+    /// <summary>Domains associated with the organization.</summary>
+    [JsonPropertyName("domains")]
+    public IEnumerable<OrganizationDomainRepresentation>? Domains { get; set; }
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/Requests/Organizations/GetOrganizationMembersRequestParameters.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Requests/Organizations/GetOrganizationMembersRequestParameters.cs
@@ -1,0 +1,22 @@
+namespace Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
+
+/// <summary>
+/// Query parameters for <see cref="IKeycloakOrganizationClient.GetOrganizationMembersAsync"/>.
+/// </summary>
+public class GetOrganizationMembersRequestParameters
+{
+    /// <summary>Whether the <see cref="Search"/> value must match exactly.</summary>
+    public bool? Exact { get; set; }
+
+    /// <summary>Pagination offset.</summary>
+    public int? First { get; set; }
+
+    /// <summary>Maximum number of results to return.</summary>
+    public int? Max { get; set; }
+
+    /// <summary>Filters by membership type (e.g. <c>MANAGED</c>, <c>UNMANAGED</c>).</summary>
+    public string? MembershipType { get; set; }
+
+    /// <summary>String matching member username, email, first, or last name.</summary>
+    public string? Search { get; set; }
+}

--- a/src/Keycloak.AuthServices.Sdk/Admin/Requests/Organizations/GetOrganizationsRequestParameters.cs
+++ b/src/Keycloak.AuthServices.Sdk/Admin/Requests/Organizations/GetOrganizationsRequestParameters.cs
@@ -1,0 +1,25 @@
+namespace Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
+
+/// <summary>
+/// Query parameters for <see cref="IKeycloakOrganizationClient.GetOrganizationsAsync"/>.
+/// </summary>
+public class GetOrganizationsRequestParameters
+{
+    /// <summary>If <c>false</c>, return the full representation. Otherwise only basic fields.</summary>
+    public bool? BriefRepresentation { get; set; }
+
+    /// <summary>Whether the <see cref="Search"/> value must match exactly.</summary>
+    public bool? Exact { get; set; }
+
+    /// <summary>Pagination offset.</summary>
+    public int? First { get; set; }
+
+    /// <summary>Maximum number of results to return.</summary>
+    public int? Max { get; set; }
+
+    /// <summary>Attribute search query in the format <c>key1:value1 key2:value2</c>.</summary>
+    public string? Query { get; set; }
+
+    /// <summary>String matching either an organization name or a registered domain.</summary>
+    public string? Search { get; set; }
+}

--- a/src/Keycloak.AuthServices.Sdk/ServiceCollectionExtensions.cs
+++ b/src/Keycloak.AuthServices.Sdk/ServiceCollectionExtensions.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Options;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/> HTTP clients for Keycloak Admin API.
+    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/>, <see cref="IKeycloakOrganizationClient"/> HTTP clients for Keycloak Admin API.
     /// </summary>
     /// <param name="services">The IServiceCollection to add the HttpClient to.</param>
     /// <param name="configuration">The IConfiguration instance to bind the Keycloak options from.</param>
@@ -32,7 +32,7 @@ public static class ServiceCollectionExtensions
         );
 
     /// <summary>
-    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/> HTTP clients for Keycloak Admin API.
+    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/>, <see cref="IKeycloakOrganizationClient"/> HTTP clients for Keycloak Admin API.
     /// </summary>
     /// <param name="services">The IServiceCollection to add the HttpClient to.</param>
     /// <param name="configurationSection">The IConfigurationSection to bind the Keycloak options from.</param>
@@ -49,7 +49,7 @@ public static class ServiceCollectionExtensions
         );
 
     /// <summary>
-    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/> for Keycloak Admin API.
+    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/>, <see cref="IKeycloakOrganizationClient"/> for Keycloak Admin API.
     /// </summary>
     /// <param name="services">The IServiceCollection to add the HttpClient to.</param>
     /// <param name="configureKeycloakOptions">An action to configure the Keycloak client options.</param>
@@ -74,6 +74,7 @@ public static class ServiceCollectionExtensions
         services.AddTransient<IKeycloakRealmClient>(sp => sp.GetRequiredService<IKeycloakClient>());
         services.AddTransient<IKeycloakUserClient>(sp => sp.GetRequiredService<IKeycloakClient>());
         services.AddTransient<IKeycloakGroupClient>(sp => sp.GetRequiredService<IKeycloakClient>());
+        services.AddTransient<IKeycloakOrganizationClient>(sp => sp.GetRequiredService<IKeycloakClient>());
 
         return services
             .AddHttpClient(
@@ -92,7 +93,7 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/> HTTP clients for Keycloak Admin API.
+    /// Adds <see cref="IKeycloakClient"/>, <see cref="IKeycloakRealmClient"/>, <see cref="IKeycloakUserClient"/>, <see cref="IKeycloakGroupClient"/>, <see cref="IKeycloakOrganizationClient"/> HTTP clients for Keycloak Admin API.
     /// </summary>
     /// <param name="services">The IServiceCollection to add the HttpClient to.</param>
     /// <param name="keycloakOptions">The Keycloak client options.</param>

--- a/tests/Keycloak.AuthServices.Sdk.Tests/KeycloakOrganizationClientTests.cs
+++ b/tests/Keycloak.AuthServices.Sdk.Tests/KeycloakOrganizationClientTests.cs
@@ -1,0 +1,346 @@
+namespace Keycloak.AuthServices.Sdk.Tests;
+
+using System.Net;
+using System.Text.Json;
+using Keycloak.AuthServices.Sdk;
+using Keycloak.AuthServices.Sdk.Admin;
+using Keycloak.AuthServices.Sdk.Admin.Models;
+using Keycloak.AuthServices.Sdk.Admin.Requests.Organizations;
+using Keycloak.AuthServices.Sdk.Utils;
+using RichardSzalay.MockHttp;
+
+public class KeycloakOrganizationClientTests
+{
+    private const string BaseAddress = "http://localhost:8080";
+    private const string MediaType = "application/json";
+    private readonly MockHttpMessageHandler handler = new();
+    private readonly IKeycloakOrganizationClient keycloakOrganizationClient;
+
+    public KeycloakOrganizationClientTests()
+    {
+        var httpClient = this.handler.ToHttpClient();
+        httpClient.BaseAddress = new Uri(BaseAddress);
+
+        this.keycloakOrganizationClient = new KeycloakClient(httpClient);
+    }
+
+    [Fact]
+    public async Task GetOrganizationsAsync_ByDefault_ReturnsOrganizations()
+    {
+        var orgs = GetOrganizationRepresentations(3);
+        var response = $"[{string.Join(",", orgs.Select(o => JsonSerializer.Serialize(o)))})]";
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationsAsync("master");
+
+        result.Select(o => o.Id).Should().BeEquivalentTo(orgs.Select(o => o.Id));
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationsAsync_WithSearch_PassesQueryString()
+    {
+        var parameters = new GetOrganizationsRequestParameters
+        {
+            Search = "example.com",
+            First = 0,
+            Max = 10,
+        };
+
+        var queryBuilder = new QueryBuilder
+        {
+            { "search", "example.com" },
+            { "first", "0" },
+            { "max", "10" },
+        };
+
+        this.handler.Expect(HttpMethod.Get, $"/admin/realms/master/organizations{queryBuilder.ToQueryString()}")
+            .Respond(HttpStatusCode.OK, MediaType, "[]");
+
+        _ = await this.keycloakOrganizationClient.GetOrganizationsAsync("master", parameters);
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationCountAsync_ReturnsCount()
+    {
+        const int orgCount = 7;
+        var response = orgCount.ToString();
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/count")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationCountAsync("master");
+
+        result.Should().Be(orgCount);
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_ByDefault_ReturnsOrganization()
+    {
+        var orgId = Guid.NewGuid();
+        var org = GetOrganizationRepresentation(orgId);
+        var orgJson = JsonSerializer.Serialize(org);
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.OK, MediaType, orgJson);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationAsync("master", orgId.ToString());
+
+        result.Id.Should().Be(orgId.ToString());
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationAsync_NotFound_ThrowsKeycloakHttpClientException()
+    {
+        var orgId = Guid.NewGuid().ToString();
+        const string errorMessage = /*lang=json,strict*/
+            "{\"error\":\"Organization not found\"}";
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.NotFound, MediaType, errorMessage);
+
+        var exception = await FluentActions
+            .Invoking(() => this.keycloakOrganizationClient.GetOrganizationAsync("master", orgId))
+            .Should()
+            .ThrowAsync<KeycloakHttpClientException>();
+
+        exception.And.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task CreateOrganizationAsync_ByDefault_PostsRepresentation()
+    {
+        var org = GetOrganizationRepresentation(Guid.NewGuid());
+        var orgJson = JsonSerializer.Serialize(org);
+
+        this.handler.Expect(HttpMethod.Post, $"{BaseAddress}/admin/realms/master/organizations")
+            .Respond(HttpStatusCode.Created, MediaType, orgJson);
+
+        await this.keycloakOrganizationClient.CreateOrganizationAsync("master", org);
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task UpdateOrganizationAsync_ByDefault_PutsRepresentation()
+    {
+        var orgId = Guid.NewGuid();
+        var org = GetOrganizationRepresentation(orgId);
+        var orgJson = JsonSerializer.Serialize(org);
+
+        this.handler.Expect(HttpMethod.Put, $"{BaseAddress}/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.NoContent);
+
+        await this.keycloakOrganizationClient.UpdateOrganizationAsync("master", orgId.ToString(), org);
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task DeleteOrganizationAsync_ByDefault_DeletesResource()
+    {
+        var orgId = Guid.NewGuid();
+
+        this.handler.Expect(HttpMethod.Delete, $"/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.NoContent);
+
+        await this.keycloakOrganizationClient.DeleteOrganizationAsync("master", orgId.ToString());
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationMembersAsync_ByDefault_ReturnsMembers()
+    {
+        var orgId = Guid.NewGuid();
+        var members = GetOrganizationMemberRepresentations(3);
+        var response = $"[{string.Join(",", members.Select(m => JsonSerializer.Serialize(m)))})]";
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationMembersAsync("master", orgId.ToString());
+
+        result.Select(m => m.Id).Should().BeEquivalentTo(members.Select(m => m.Id));
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationMembersAsync_WithParameters_PassesQueryString()
+    {
+        var orgId = Guid.NewGuid();
+        var parameters = new GetOrganizationMembersRequestParameters
+        {
+            MembershipType = "UNMANAGED",
+            Search = "user",
+            First = 0,
+            Max = 20,
+        };
+
+        var queryBuilder = new QueryBuilder
+        {
+            { "membershipType", "UNMANAGED" },
+            { "search", "user" },
+            { "first", "0" },
+            { "max", "20" },
+        };
+
+        this.handler.Expect(HttpMethod.Get, $"/admin/realms/master/organizations/{orgId}/members{queryBuilder.ToQueryString()}")
+            .Respond(HttpStatusCode.OK, MediaType, "[]");
+
+        _ = await this.keycloakOrganizationClient.GetOrganizationMembersAsync("master", orgId.ToString(), parameters);
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationMemberCountAsync_ReturnsCount()
+    {
+        const int memberCount = 15;
+        var response = memberCount.ToString();
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/org1/members/count")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationMemberCountAsync("master", "org1");
+
+        result.Should().Be(memberCount);
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationMemberAsync_ByDefault_ReturnsMember()
+    {
+        var orgId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+        var member = GetOrganizationMemberRepresentation(memberId);
+        var memberJson = JsonSerializer.Serialize(member);
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members/{memberId}")
+            .Respond(HttpStatusCode.OK, MediaType, memberJson);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationMemberAsync("master", orgId.ToString(), memberId.ToString());
+
+        result.Id.Should().Be(memberId.ToString());
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task AddOrganizationMemberAsync_ByDefault_PostsUserIdAsJsonString()
+    {
+        const string realm = "master";
+        const string orgId = "org-1";
+        const string userId = "user-1";
+
+        this.handler
+            .Expect(HttpMethod.Post, $"/admin/realms/{realm}/organizations/{orgId}/members")
+            .WithRequestBody($"\"{userId}\"")
+            .RespondWith(new MockHttpResponse { StatusCode = HttpStatusCode.NoContent });
+
+        await this.keycloakOrganizationClient.AddOrganizationMemberAsync(realm, orgId, userId);
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task RemoveOrganizationMemberAsync_ByDefault_DeletesResource()
+    {
+        var orgId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+
+        this.handler.Expect(HttpMethod.Delete, $"/admin/realms/master/organizations/{orgId}/members/{memberId}")
+            .Respond(HttpStatusCode.NoContent);
+
+        await this.keycloakOrganizationClient.RemoveOrganizationMemberAsync("master", orgId.ToString(), memberId.ToString());
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetOrganizationMemberGroupsAsync_ByDefault_ReturnsGroups()
+    {
+        var orgId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+        var groups = GetGroupRepresentations(2);
+        var response = $"[{string.Join(",", groups.Select(g => JsonSerializer.Serialize(g)))})]";
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members/{memberId}/groups")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetOrganizationMemberGroupsAsync("master", orgId.ToString(), memberId.ToString());
+
+        result.Select(g => g.Id).Should().BeEquivalentTo(groups.Select(g => g.Id));
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetUserOrganizationsAsync_ByDefault_ReturnsOrganizations()
+    {
+        var memberId = Guid.NewGuid();
+        var orgs = GetOrganizationRepresentations(2);
+        var response = $"[{string.Join(",", orgs.Select(o => JsonSerializer.Serialize(o)))})]";
+
+        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/members/{memberId}/organizations")
+            .Respond(HttpStatusCode.OK, MediaType, response);
+
+        var result = await this.keycloakOrganizationClient.GetUserOrganizationsAsync("master", memberId.ToString());
+
+        result.Select(o => o.Id).Should().BeEquivalentTo(orgs.Select(o => o.Id));
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    private static OrganizationRepresentation GetOrganizationRepresentation(Guid id) => new()
+    {
+        Id = id.ToString(),
+        Name = $"Org-{id}",
+        Alias = $"org-{id}",
+        Enabled = true,
+        Description = $"Description for org-{id}",
+        RedirectUrl = $"https://org-{id}.example.com",
+        Attributes = null,
+        Domains = null
+    };
+
+    private static IEnumerable<OrganizationRepresentation> GetOrganizationRepresentations(int count) => Enumerable
+        .Range(0, count)
+        .Select(i => GetOrganizationRepresentation(Guid.NewGuid()));
+
+    private static OrganizationMemberRepresentation GetOrganizationMemberRepresentation(Guid id) => new()
+    {
+        Id = id.ToString(),
+        Username = $"user-{id}",
+        Email = $"user-{id}@example.com",
+        FirstName = $"First-{id}",
+        LastName = $"Last-{id}",
+        Enabled = true,
+        MembershipType = "UNMANAGED"
+    };
+
+    private static IEnumerable<OrganizationMemberRepresentation> GetOrganizationMemberRepresentations(int count) => Enumerable
+        .Range(0, count)
+        .Select(i => GetOrganizationMemberRepresentation(Guid.NewGuid()));
+
+    private static GroupRepresentation GetGroupRepresentation(Guid id) => new()
+    {
+        Id = id.ToString(),
+        Name = $"Group-{id}",
+        Description = $"Description for group-{id}",
+        RealmId = "master",
+        ParentId = null,
+        Path = $"/Group-{id}",
+        Attributes = null,
+        ClientRoles = null,
+        UserRoles = null
+    };
+
+    private static IEnumerable<GroupRepresentation> GetGroupRepresentations(int count) => Enumerable
+        .Range(0, count)
+        .Select(i => GetGroupRepresentation(Guid.NewGuid()));
+}

--- a/tests/Keycloak.AuthServices.Sdk.Tests/KeycloakOrganizationClientTests.cs
+++ b/tests/Keycloak.AuthServices.Sdk.Tests/KeycloakOrganizationClientTests.cs
@@ -25,10 +25,18 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationsAsync_ByDefault_ReturnsOrganizations()
+    public async Task GetOrganizationsShouldReturnOrganizations()
     {
-        var orgs = GetOrganizationRepresentations(3);
-        var response = $"[{string.Join(",", orgs.Select(o => JsonSerializer.Serialize(o)))})]";
+        var orgs = Enumerable
+            .Range(0, 3)
+            .Select(_ =>
+            {
+                var id = Guid.NewGuid();
+                return (Id: id.ToString(), Representation: GetOrganizationRepresentation(id));
+            })
+            .ToArray();
+
+        var response = $"[{string.Join(",", orgs.Select(o => o.Representation))}]";
 
         this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations")
             .Respond(HttpStatusCode.OK, MediaType, response);
@@ -40,7 +48,7 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationsAsync_WithSearch_PassesQueryString()
+    public async Task GetOrganizationsShouldCallCorrectEndpointWithOptionalQueryParameters()
     {
         var parameters = new GetOrganizationsRequestParameters
         {
@@ -65,10 +73,12 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationCountAsync_ReturnsCount()
+    public async Task GetOrganizationCountShouldCallCorrectEndpoint()
     {
         const int orgCount = 7;
+#pragma warning disable CA1305 // use locale provider
         var response = orgCount.ToString();
+#pragma warning restore CA1305 // use locale provider
 
         this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/count")
             .Respond(HttpStatusCode.OK, MediaType, response);
@@ -80,14 +90,12 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationAsync_ByDefault_ReturnsOrganization()
+    public async Task GetOrganizationShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
-        var org = GetOrganizationRepresentation(orgId);
-        var orgJson = JsonSerializer.Serialize(org);
 
-        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}")
-            .Respond(HttpStatusCode.OK, MediaType, orgJson);
+        this.handler.Expect(HttpMethod.Get, $"/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.OK, MediaType, GetOrganizationRepresentation(orgId));
 
         var result = await this.keycloakOrganizationClient.GetOrganizationAsync("master", orgId.ToString());
 
@@ -96,7 +104,7 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationAsync_NotFound_ThrowsKeycloakHttpClientException()
+    public async Task GetOrganizationShouldThrowNotFoundApiExceptionWhenOrganizationDoesNotExist()
     {
         var orgId = Guid.NewGuid().ToString();
         const string errorMessage = /*lang=json,strict*/
@@ -111,40 +119,38 @@ public class KeycloakOrganizationClientTests
             .ThrowAsync<KeycloakHttpClientException>();
 
         exception.And.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
+        exception.And.Response?.Error.Should().Be("Organization not found");
         this.handler.VerifyNoOutstandingExpectation();
     }
 
     [Fact]
-    public async Task CreateOrganizationAsync_ByDefault_PostsRepresentation()
-    {
-        var org = GetOrganizationRepresentation(Guid.NewGuid());
-        var orgJson = JsonSerializer.Serialize(org);
-
-        this.handler.Expect(HttpMethod.Post, $"{BaseAddress}/admin/realms/master/organizations")
-            .Respond(HttpStatusCode.Created, MediaType, orgJson);
-
-        await this.keycloakOrganizationClient.CreateOrganizationAsync("master", org);
-
-        this.handler.VerifyNoOutstandingExpectation();
-    }
-
-    [Fact]
-    public async Task UpdateOrganizationAsync_ByDefault_PutsRepresentation()
+    public async Task CreateOrganizationShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
-        var org = GetOrganizationRepresentation(orgId);
-        var orgJson = JsonSerializer.Serialize(org);
 
-        this.handler.Expect(HttpMethod.Put, $"{BaseAddress}/admin/realms/master/organizations/{orgId}")
-            .Respond(HttpStatusCode.NoContent);
+        this.handler.Expect(HttpMethod.Post, $"{BaseAddress}/admin/realms/master/organizations")
+            .Respond(HttpStatusCode.Created);
 
-        await this.keycloakOrganizationClient.UpdateOrganizationAsync("master", orgId.ToString(), org);
+        await this.keycloakOrganizationClient.CreateOrganizationAsync("master", new() { Name = $"Org-{orgId}" });
 
         this.handler.VerifyNoOutstandingExpectation();
     }
 
     [Fact]
-    public async Task DeleteOrganizationAsync_ByDefault_DeletesResource()
+    public async Task UpdateOrganizationShouldCallCorrectEndpoint()
+    {
+        var orgId = Guid.NewGuid();
+
+        this.handler.Expect(HttpMethod.Put, $"/admin/realms/master/organizations/{orgId}")
+            .Respond(HttpStatusCode.NoContent);
+
+        await this.keycloakOrganizationClient.UpdateOrganizationAsync("master", orgId.ToString(), new() { Name = $"Org-{orgId}" });
+
+        this.handler.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task DeleteOrganizationShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
 
@@ -157,11 +163,19 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationMembersAsync_ByDefault_ReturnsMembers()
+    public async Task GetOrganizationMembersShouldReturnMembers()
     {
         var orgId = Guid.NewGuid();
-        var members = GetOrganizationMemberRepresentations(3);
-        var response = $"[{string.Join(",", members.Select(m => JsonSerializer.Serialize(m)))})]";
+        var members = Enumerable
+            .Range(0, 3)
+            .Select(_ =>
+            {
+                var id = Guid.NewGuid();
+                return (Id: id.ToString(), Representation: GetOrganizationMemberRepresentation(id));
+            })
+            .ToArray();
+
+        var response = $"[{string.Join(",", members.Select(m => m.Representation))}]";
 
         this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members")
             .Respond(HttpStatusCode.OK, MediaType, response);
@@ -173,7 +187,7 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationMembersAsync_WithParameters_PassesQueryString()
+    public async Task GetOrganizationMembersShouldCallCorrectEndpointWithOptionalQueryParameters()
     {
         var orgId = Guid.NewGuid();
         var parameters = new GetOrganizationMembersRequestParameters
@@ -201,10 +215,12 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationMemberCountAsync_ReturnsCount()
+    public async Task GetOrganizationMemberCountShouldCallCorrectEndpoint()
     {
         const int memberCount = 15;
+#pragma warning disable CA1305 // use locale provider
         var response = memberCount.ToString();
+#pragma warning restore CA1305 // use locale provider
 
         this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/org1/members/count")
             .Respond(HttpStatusCode.OK, MediaType, response);
@@ -216,15 +232,13 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationMemberAsync_ByDefault_ReturnsMember()
+    public async Task GetOrganizationMemberShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
         var memberId = Guid.NewGuid();
-        var member = GetOrganizationMemberRepresentation(memberId);
-        var memberJson = JsonSerializer.Serialize(member);
 
-        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members/{memberId}")
-            .Respond(HttpStatusCode.OK, MediaType, memberJson);
+        this.handler.Expect(HttpMethod.Get, $"/admin/realms/master/organizations/{orgId}/members/{memberId}")
+            .Respond(HttpStatusCode.OK, MediaType, GetOrganizationMemberRepresentation(memberId));
 
         var result = await this.keycloakOrganizationClient.GetOrganizationMemberAsync("master", orgId.ToString(), memberId.ToString());
 
@@ -233,7 +247,7 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task AddOrganizationMemberAsync_ByDefault_PostsUserIdAsJsonString()
+    public async Task AddOrganizationMemberShouldCallCorrectEndpoint()
     {
         const string realm = "master";
         const string orgId = "org-1";
@@ -241,8 +255,8 @@ public class KeycloakOrganizationClientTests
 
         this.handler
             .Expect(HttpMethod.Post, $"/admin/realms/{realm}/organizations/{orgId}/members")
-            .WithRequestBody($"\"{userId}\"")
-            .RespondWith(new MockHttpResponse { StatusCode = HttpStatusCode.NoContent });
+            .WithContent($"\"{userId}\"")
+            .Respond(HttpStatusCode.NoContent);
 
         await this.keycloakOrganizationClient.AddOrganizationMemberAsync(realm, orgId, userId);
 
@@ -250,7 +264,7 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task RemoveOrganizationMemberAsync_ByDefault_DeletesResource()
+    public async Task RemoveOrganizationMemberShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
         var memberId = Guid.NewGuid();
@@ -264,28 +278,38 @@ public class KeycloakOrganizationClientTests
     }
 
     [Fact]
-    public async Task GetOrganizationMemberGroupsAsync_ByDefault_ReturnsGroups()
+    public async Task GetOrganizationMemberGroupsShouldCallCorrectEndpoint()
     {
         var orgId = Guid.NewGuid();
         var memberId = Guid.NewGuid();
-        var groups = GetGroupRepresentations(2);
-        var response = $"[{string.Join(",", groups.Select(g => JsonSerializer.Serialize(g)))})]";
 
-        this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/{orgId}/members/{memberId}/groups")
-            .Respond(HttpStatusCode.OK, MediaType, response);
+        this.handler.Expect(HttpMethod.Get, $"/admin/realms/master/organizations/{orgId}/members/{memberId}/groups")
+            .Respond(
+                HttpStatusCode.OK,
+                MediaType,
+                JsonSerializer.Serialize(Array.Empty<GroupRepresentation>())
+            );
 
         var result = await this.keycloakOrganizationClient.GetOrganizationMemberGroupsAsync("master", orgId.ToString(), memberId.ToString());
 
-        result.Select(g => g.Id).Should().BeEquivalentTo(groups.Select(g => g.Id));
+        result.Should().BeEmpty();
         this.handler.VerifyNoOutstandingExpectation();
     }
 
     [Fact]
-    public async Task GetUserOrganizationsAsync_ByDefault_ReturnsOrganizations()
+    public async Task GetUserOrganizationsShouldCallCorrectEndpoint()
     {
         var memberId = Guid.NewGuid();
-        var orgs = GetOrganizationRepresentations(2);
-        var response = $"[{string.Join(",", orgs.Select(o => JsonSerializer.Serialize(o)))})]";
+        var orgs = Enumerable
+            .Range(0, 2)
+            .Select(_ =>
+            {
+                var id = Guid.NewGuid();
+                return (Id: id.ToString(), Representation: GetOrganizationRepresentation(id));
+            })
+            .ToArray();
+
+        var response = $"[{string.Join(",", orgs.Select(o => o.Representation))}]";
 
         this.handler.Expect(HttpMethod.Get, $"{BaseAddress}/admin/realms/master/organizations/members/{memberId}/organizations")
             .Respond(HttpStatusCode.OK, MediaType, response);
@@ -296,51 +320,28 @@ public class KeycloakOrganizationClientTests
         this.handler.VerifyNoOutstandingExpectation();
     }
 
-    private static OrganizationRepresentation GetOrganizationRepresentation(Guid id) => new()
-    {
-        Id = id.ToString(),
-        Name = $"Org-{id}",
-        Alias = $"org-{id}",
-        Enabled = true,
-        Description = $"Description for org-{id}",
-        RedirectUrl = $"https://org-{id}.example.com",
-        Attributes = null,
-        Domains = null
-    };
+    private static string GetOrganizationRepresentation(Guid orgId) =>
+        /*lang=json,strict*/"""
+        {
+            "id": "{orgId}",
+            "name": "Org-{orgId}",
+            "alias": "org-{orgId}",
+            "enabled": true,
+            "description": "Description for org-{orgId}",
+            "redirectUrl": "https://org-{orgId}.example.com"
+        }
+        """.Replace("{orgId}", orgId.ToString());
 
-    private static IEnumerable<OrganizationRepresentation> GetOrganizationRepresentations(int count) => Enumerable
-        .Range(0, count)
-        .Select(i => GetOrganizationRepresentation(Guid.NewGuid()));
-
-    private static OrganizationMemberRepresentation GetOrganizationMemberRepresentation(Guid id) => new()
-    {
-        Id = id.ToString(),
-        Username = $"user-{id}",
-        Email = $"user-{id}@example.com",
-        FirstName = $"First-{id}",
-        LastName = $"Last-{id}",
-        Enabled = true,
-        MembershipType = "UNMANAGED"
-    };
-
-    private static IEnumerable<OrganizationMemberRepresentation> GetOrganizationMemberRepresentations(int count) => Enumerable
-        .Range(0, count)
-        .Select(i => GetOrganizationMemberRepresentation(Guid.NewGuid()));
-
-    private static GroupRepresentation GetGroupRepresentation(Guid id) => new()
-    {
-        Id = id.ToString(),
-        Name = $"Group-{id}",
-        Description = $"Description for group-{id}",
-        RealmId = "master",
-        ParentId = null,
-        Path = $"/Group-{id}",
-        Attributes = null,
-        ClientRoles = null,
-        UserRoles = null
-    };
-
-    private static IEnumerable<GroupRepresentation> GetGroupRepresentations(int count) => Enumerable
-        .Range(0, count)
-        .Select(i => GetGroupRepresentation(Guid.NewGuid()));
+    private static string GetOrganizationMemberRepresentation(Guid memberId) =>
+        /*lang=json,strict*/"""
+        {
+            "id": "{memberId}",
+            "username": "user-{memberId}",
+            "email": "user-{memberId}@example.com",
+            "firstName": "First-{memberId}",
+            "lastName": "Last-{memberId}",
+            "enabled": true,
+            "membershipType": "UNMANAGED"
+        }
+        """.Replace("{memberId}", memberId.ToString());
 }


### PR DESCRIPTION
Full disclosure - plans made with openspec and slopped with qwen 3.6 27b/nvidia V100.

Adds support for organizations as described in the [latest keycloak api definition ](https://www.[keycloak.org/docs-api/latest/rest-api/openapi.json](https://www.keycloak.org/docs-api/latest/rest-api/openapi.json)).

Submitting but leaving in draft until I fully review (I've only done a quick pass) and make any required amendments. 